### PR TITLE
Fix to LHE in/out ratio (1:160)

### DIFF
--- a/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
+++ b/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_HeatExchanger.java
@@ -123,16 +123,29 @@ public class GT_MetaTileEntity_HeatExchanger extends GT_MetaTileEntity_MultiBloc
 	  
 	  public boolean onRunningTick(ItemStack aStack)
 	  { 
-	    if (this.mEUt > 0)
-	    {
-	      int tGeneratedEU = (int)(this.mEUt * 2L * this.mEfficiency / 10000L);
-	      if (tGeneratedEU > 0) {
-	        if (depleteInput(GT_ModHandler.getDistilledWater(useWater(((float)(superheated ? tGeneratedEU/2 :tGeneratedEU) + 160f) / 160f)))) {
-							if(superheated){addOutput(FluidRegistry.getFluidStack("ic2superheatedsteam", tGeneratedEU/2));
-							}else{
-	          addOutput(GT_ModHandler.getSteam(tGeneratedEU));}
-	        } else {
-	          explodeMultiblock();
+	      int tGeneratedEU = (int)(this.mEUt * 2L * this.mEfficiency / 10000L);  // APPROXIMATELY how much steam to generate.
+	      if (tGeneratedEU > 0) 
+	      {
+	    	if (superheated)
+	    		tGeneratedEU /= 2;
+	    	
+	    	int distilledConsumed = (int) Math.round(tGeneratedEU / 160f);  // how much distilled water to consume
+	    	tGeneratedEU = distilledConsumed * 160;  // EXACTLY how much steam to generate, producing a perfect 1:160 ratio with distilled water consumption
+	    	FluidStack distilledStack = GT_ModHandler.getDistilledWater(useWater(distilledConsumed));
+  	        if (depleteInput(distilledStack)) // Consume the distilled water
+	        {
+		  if(superheated)
+		  {
+			  addOutput(FluidRegistry.getFluidStack("ic2superheatedsteam", tGeneratedEU));  // Generate superheated steam
+		  }
+		  else
+		  {
+			  addOutput(GT_ModHandler.getSteam(tGeneratedEU)); // Generate regular steam
+          	  }
+	        } 
+	        else 
+	        {
+	          explodeMultiblock(); // Generate crater
 	        }
 	      }
 	      return true;


### PR DESCRIPTION
Blood, I'm submitting this just for you to look at.  
I think your useWater method should work just fine but I've had no luck with it.  See if this is an acceptable workaround.

As discussed, the method now accepts the "target steam output".  We then determine how much distilled water we're going to consume (to the nearest integer) and calculate the "actual steam output" from that.

Testing demonstrates virtually identical overall steam output to the old method.  The big difference is that we always get a perfect 1:160 ratio of distilledwater:steam.

This does NOT investigate whether total output numbers are correct ( I don't know if they are or not ).

Sorry about...
{
  how I do brackets;
}