### PR TITLE
Let GT AdvCircuits trigger the "stepforward" achievement

### DIFF
--- a/main/java/gregtech/loaders/misc/GT_Achievements.java
+++ b/main/java/gregtech/loaders/misc/GT_Achievements.java
@@ -484,6 +484,8 @@ public int adjY = 9;
 				issueAchievement(player, "filterregulate");
 			}else if(stack.getUnlocalizedName().equals("gt.metaitem.01.32605")){
 				issueAchievement(player, "whatnow");
+			}else if(stack.getUnlocalizedName().equals("gt.metaitem.01.32703")){
+				issueAchievement(player, "stepforward");
 			}
 		}else if(stack.getUnlocalizedName().equals("ic2.itemPartCircuitAdv")){
 			issueAchievement(player, "stepforward");


### PR DESCRIPTION
..or else anyone that is unifying their circuits to the nicer-looking GT variants will miss out on this achievement.