### PR TITLE
Fix for large steam turbines producing only half EU/t

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_HPSteam.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_HPSteam.java
@@ -96,9 +96,9 @@ public class GT_MetaTileEntity_LargeTurbine_HPSteam extends GT_MetaTileEntity_La
         if (totalFlow > 0 && totalFlow != aOptFlow) {
             float efficiency = 1.0f - Math.abs(((totalFlow - (float) aOptFlow) / aOptFlow));
             tEU *= efficiency;
-            tEU = Math.max(1, tEU * aBaseEff / 10000);
+            tEU = Math.max(1, tEU * aBaseEff / 5000);
         } else {
-            tEU = tEU * aBaseEff / 10000;
+            tEU = tEU * aBaseEff / 5000;
         }
 
         return tEU;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Steam.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine_Steam.java
@@ -107,9 +107,9 @@ public class GT_MetaTileEntity_LargeTurbine_Steam extends GT_MetaTileEntity_Larg
         if (totalFlow > 0 && totalFlow != aOptFlow) {
             float efficiency = 1.0f - Math.abs(((totalFlow - (float) aOptFlow) / aOptFlow));
             tEU *= efficiency;
-            tEU = Math.max(1, tEU * aBaseEff / 20000);
+            tEU = Math.max(1, tEU * aBaseEff / 10000);
         } else {
-            tEU = tEU * aBaseEff / 20000;
+            tEU = tEU * aBaseEff / 10000;
         }
 
         return tEU;


### PR DESCRIPTION
Fixed large steam and large HP steam turbines so that they produce the standard 2mb/EU and 1mb/EU, respectively.
