### PR TITLE
Fix boost of starting of fusion reactors

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
@@ -367,7 +367,11 @@ public abstract class GT_MetaTileEntity_FusionComputer extends GT_MetaTileEntity
                                 turnCasingActive(mMaxProgresstime > 0);
                                 if (aBaseMetaTileEntity.isAllowedToWork()) {
                                     this.mEUStore = (int) aBaseMetaTileEntity.getStoredEU();
-                                    if (checkRecipe(mInventory[1]) && aBaseMetaTileEntity.getStoredEU() >= this.mLastRecipe.mSpecialValue) {
+                                    if (checkRecipe(mInventory[1])) {
+                                        if (this.mEUStore < this.mLastRecipe.mSpecialValue) {
+                                            mMaxProgresstime = 0;
+                                            turnCasingActive(false);
+                                        }
                                         aBaseMetaTileEntity.decreaseStoredEnergyUnits(this.mLastRecipe.mSpecialValue, true);
                                     }
                                 }


### PR DESCRIPTION
> T1 Fusion with 4 energy hatches can contain only 39 998 488 eU instead of 40 M.

Not fix it but I think I fixed another problem. #447 #270 
In my branch the fusion reactor always consumes stored energy while trying to start. Therefore you should disable it with a soft hummer and turn on the fusion reactor when it accumulated energy for start. Then the fusion reactor will works as usual.

Need to be tested. From my side:
I tested only T1 with 16 energy hatches with recipe of helium plasma.
