### PR TITLE
Fix 'cannot find symbol' error in AdvMiner2

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AdvMiner2.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AdvMiner2.java
@@ -133,7 +133,7 @@ public class GT_MetaTileEntity_AdvMiner2 extends GT_MetaTileEntity_MultiBlockBas
             }
             ArrayList<ItemStack> tDrops = new ArrayList();
             Block tMineBlock = null;
-            ChunkPosition mle;
+            ChunkPosition mle = null;;
             while ((tMineBlock==null || tMineBlock == Blocks.air) && !mMineList.isEmpty()) {
                 mle = mMineList.get(0);
                 mMineList.remove(0);

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AdvMiner2.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AdvMiner2.java
@@ -134,8 +134,9 @@ public class GT_MetaTileEntity_AdvMiner2 extends GT_MetaTileEntity_MultiBlockBas
             ArrayList<ItemStack> tDrops = new ArrayList();
             if (!mMineList.isEmpty()) {
                 Block tMineBlock = null;
+                ChunkPosition mle;
                 while ((tMineBlock==null || tMineBlock == Blocks.air) && !mMineList.isEmpty()) {
-                    ChunkPosition mle = mMineList.get(0);
+                    mle = mMineList.get(0);
                     mMineList.remove(0);
                     tMineBlock = getBaseMetaTileEntity().getBlockOffset(mle.chunkPosX, mle.chunkPosY, mle.chunkPosZ);
                 }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AdvMiner2.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_AdvMiner2.java
@@ -132,14 +132,15 @@ public class GT_MetaTileEntity_AdvMiner2 extends GT_MetaTileEntity_MultiBlockBas
                 }
             }
             ArrayList<ItemStack> tDrops = new ArrayList();
-            if (!mMineList.isEmpty()) {
-                Block tMineBlock = null;
-                ChunkPosition mle;
-                while ((tMineBlock==null || tMineBlock == Blocks.air) && !mMineList.isEmpty()) {
-                    mle = mMineList.get(0);
-                    mMineList.remove(0);
-                    tMineBlock = getBaseMetaTileEntity().getBlockOffset(mle.chunkPosX, mle.chunkPosY, mle.chunkPosZ);
-                }
+            Block tMineBlock = null;
+            ChunkPosition mle;
+            while ((tMineBlock==null || tMineBlock == Blocks.air) && !mMineList.isEmpty()) {
+                mle = mMineList.get(0);
+                mMineList.remove(0);
+                tMineBlock = getBaseMetaTileEntity().getBlockOffset(mle.chunkPosX, mle.chunkPosY, mle.chunkPosZ);
+            }
+            
+            if (tMineBlock!=null && tMineBlock!=Blocks.air) {
                 int metadata = getBaseMetaTileEntity().getMetaIDOffset(mle.chunkPosX, mle.chunkPosY, mle.chunkPosZ);
                 boolean silkTouch = tMineBlock.canSilkHarvest(getBaseMetaTileEntity().getWorld(), null, mle.chunkPosX, mle.chunkPosY, mle.chunkPosZ, metadata);
                 if (silkTouch){


### PR DESCRIPTION
This fixes the error introduced by #542 and makes the Advanced Miner II skip blocks from the mine list which have been set to air after being added to the mine list.
