### PR TITLE
Fluid Filter, Reactoria, MK3 Naquadah reactor fixes

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
@@ -34,13 +34,14 @@ public class GT_Cover_Fluidfilter
             if(tFluid!=null){
             	//System.out.println(tFluid.getLocalizedName()+" "+tFluid.getFluidID());
             	aCoverVariable = tFluid.getFluidID();
-            aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
+                aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
         	FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aCoverVariable),1000);
-            GT_Utility.sendChatToPlayer(aPlayer, "Filter Fluid: " + sFluid.getLocalizedName());
+                GT_Utility.sendChatToPlayer(aPlayer, "Filter Fluid: " + sFluid.getLocalizedName());
             }else if(tStack.getItem() instanceof IFluidContainerItem){
             	IFluidContainerItem tContainer = (IFluidContainerItem)tStack.getItem();
                 if(tContainer.getFluid(tStack) != null) {
                     aCoverVariable = tContainer.getFluid(tStack).getFluidID();
+                    aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
                     //System.out.println("fluidcontainer " + aCoverVariable);
                     FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aCoverVariable), 1000);
                     GT_Utility.sendChatToPlayer(aPlayer, "Filter Fluid: " + sFluid.getLocalizedName());

--- a/src/main/java/gregtech/loaders/load/GT_FuelLoader.java
+++ b/src/main/java/gregtech/loaders/load/GT_FuelLoader.java
@@ -24,7 +24,7 @@ public class GT_FuelLoader
 
         GT_Recipe.GT_Recipe_Map.sSmallNaquadahReactorFuels.addRecipe(true, new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.NaquadahEnriched, 1L)}, new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Naquadah, 1L)}, null, null, null, 0, 0, 25000);
         GT_Recipe.GT_Recipe_Map.sLargeNaquadahReactorFuels.addRecipe(true, new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.NaquadahEnriched, 1L)}, new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Naquadah, 1L)}, null, null, null, 0, 0, 200000);
-        GT_Recipe.GT_Recipe_Map.sFluidNaquadahReactorFuels.addRecipe(true, new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.cell, Materials.NaquadahEnriched, 1L)}, new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Empty, 1L)}, null, null, null, 0, 0, 200000);
+        GT_Recipe.GT_Recipe_Map.sFluidNaquadahReactorFuels.addRecipe(true, new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.cell, Materials.NaquadahEnriched, 1L)}, new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.cell,  Materials.Naquadah, 1L)}, null, null, null, 0, 0, 200000);
 
         GT_Values.RA.addFuel(GT_ModHandler.getModItem("Thaumcraft", "ItemResource", 1L, 4), null, 4, 5);
         GT_Values.RA.addFuel(new ItemStack(Items.experience_bottle, 1), null, 10, 5);

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -1766,6 +1766,8 @@ if(Loader.isModLoaded("Railcraft")){
 		addProcess(tCrop,Materials.Osmium,20);
 
 	    // Radioactive Line
+	    	tCrop = ItemList.Crop_Drop_Pitchblende.get(1, new Object[0]);
+	    	addProcess(tCrop,Materials.Pitchblende,50);
 		tCrop = ItemList.Crop_Drop_Uraninite.get(1, new Object[0]);
 		addProcess(tCrop,Materials.Uraninite,50);
 		addProcess(tCrop,Materials.Uranium,50);


### PR DESCRIPTION
Some fixes.
1) Fluid filter fix.
2) Added pitchblende multiplication recipe with Reactoria leaves.
3) Changed MK3 Naquadah Reactor to return naquadah cell instead of empty cell.
