### PR TITLE
GC Ore Support

### DIFF
--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -176,7 +176,7 @@ public class GregTech_API {
      */
     public static Block sBlockMachines;
 
-    public static Block sBlockOres1, sBlockOresUb1, sBlockOresUb2, sBlockOresUb3, sBlockGem, sBlockMetal1, sBlockMetal2, sBlockMetal3, sBlockMetal4, sBlockMetal5, sBlockMetal6, sBlockMetal7, sBlockMetal8, sBlockGem1, sBlockGem2, sBlockGem3, sBlockReinforced;
+    public static Block sBlockOres1, sBlockOresUb1, sBlockOresUb2, sBlockOresUb3, sBlockOresGC, sBlockGem, sBlockMetal1, sBlockMetal2, sBlockMetal3, sBlockMetal4, sBlockMetal5, sBlockMetal6, sBlockMetal7, sBlockMetal8, sBlockGem1, sBlockGem2, sBlockGem3, sBlockReinforced;
     public static Block sBlockGranites, sBlockConcretes, sBlockStones;
     public static Block sBlockCasings1, sBlockCasings2, sBlockCasings3, sBlockCasings4, sBlockCasings5;
     /**

--- a/src/main/java/gregtech/common/GT_Worldgen_Stone.java
+++ b/src/main/java/gregtech/common/GT_Worldgen_Stone.java
@@ -60,7 +60,6 @@ public class GT_Worldgen_Stone
                                                 if (tTargetedBlock instanceof GT_Block_Ores_Abstract) {
                                                     TileEntity tTileEntity = aWorld.getTileEntity(eX, eY, eZ);
                                                     if ((tTileEntity instanceof GT_TileEntity_Ores)) {
-                                                        short aMeta = ((GT_TileEntity_Ores) tTileEntity).mMetaData;
                                                         if (tTargetedBlock != GregTech_API.sBlockOres1) {
                                                             ((GT_TileEntity_Ores) tTileEntity).convertOreBlock(aWorld, eX, eY, eZ);
                                                         }

--- a/src/main/java/gregtech/common/GT_Worldgenerator.java
+++ b/src/main/java/gregtech/common/GT_Worldgenerator.java
@@ -124,8 +124,9 @@ public class GT_Worldgenerator
             }
             //Asteroid Worldgen
             int tDimensionType = this.mWorld.provider.dimensionId;
+            String tDimensionName = this.mWorld.provider.getDimensionName();
             Random aRandom = new Random();
-            if (((tDimensionType == 1) && endAsteroids && ((mEndAsteroidProbability <= 1) || (aRandom.nextInt(mEndAsteroidProbability) == 0))) || ((tDimensionType == -30) && gcAsteroids && ((mGCAsteroidProbability <= 1) || (aRandom.nextInt(mGCAsteroidProbability) == 0)))) {
+            if (((tDimensionType == 1) && endAsteroids && ((mEndAsteroidProbability <= 1) || (aRandom.nextInt(mEndAsteroidProbability) == 0))) || ((tDimensionName.equals("Asteroids")) && gcAsteroids && ((mGCAsteroidProbability <= 1) || (aRandom.nextInt(mGCAsteroidProbability) == 0)))) {
 
                 short primaryMeta = 0;
                 short secondaryMeta = 0;
@@ -160,7 +161,7 @@ public class GT_Worldgenerator
                 int tZ = mZ + aRandom.nextInt(16);
                 if (tDimensionType == 1) {
                     mSize = aRandom.nextInt((int) (endMaxSize - endMinSize));
-                } else if (tDimensionType == -30) {
+                } else if (tDimensionName.equals("Asteroids")) {
                     mSize = aRandom.nextInt((int) (gcMaxSize - gcMinSize));
                 }
                 if ((mWorld.getBlock(tX, tY, tZ).isAir(mWorld, tX, tY, tZ))) {
@@ -205,7 +206,7 @@ public class GT_Worldgenerator
                                                 } else {
                                                     if (tDimensionType == -1) {
                                                         mWorld.setBlock(eX, eY, eZ, Blocks.end_stone, 0, 0);
-                                                    } else if (tDimensionType == -30) {
+                                                    } else if (tDimensionName.equals("Asteroids")) {
                                                         //int asteroidType = aRandom.nextInt(20);
                                                         //if (asteroidType == 19) { //Rare Asteroid?
                                                             //mWorld.setBlock(eX, eY, eZ, GregTech_API.sBlockGranites, 8, 3);

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores.java
@@ -13,7 +13,7 @@ import net.minecraft.init.Blocks;
 
 public class GT_Block_Ores extends GT_Block_Ores_Abstract {
     public GT_Block_Ores() {
-        super("gt.blockores", false, Material.rock);
+        super("gt.blockores", 7, false, Material.rock);
     }
 
     @Override
@@ -34,11 +34,6 @@ public class GT_Block_Ores extends GT_Block_Ores_Abstract {
     @Override
     public Materials[] getDroppedDusts() { //Must have 8 entries; can be null.
         return new Materials[]{Materials.Stone, Materials.Netherrack, Materials.Endstone, Materials.GraniteBlack, Materials.GraniteRed, Materials.Marble, Materials.Basalt, Materials.Stone};
-    }
-
-    @Override
-    public int getHarvestLevel(int aMeta) {
-        return aMeta == 5 || aMeta == 6 ? 2 : aMeta % 8;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_Abstract.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_Abstract.java
@@ -36,60 +36,31 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
     public static ThreadLocal<GT_TileEntity_Ores> mTemporaryTileEntity = new ThreadLocal();
     public static boolean FUCKING_LOCK = false;
     public static boolean tHideOres;
+    public static int tOreMetaCount;
 
-    protected GT_Block_Ores_Abstract(String aUnlocalizedName, boolean aHideFirstMeta, Material aMaterial) {
+    protected GT_Block_Ores_Abstract(String aUnlocalizedName, int aOreMetaCount, boolean aHideFirstMeta, Material aMaterial) {
         super(GT_Item_Ores.class, aUnlocalizedName, aMaterial);
         this.isBlockContainer = true;
         setStepSound(soundTypeStone);
         setCreativeTab(GregTech_API.TAB_GREGTECH_ORES);
         tHideOres = Loader.isModLoaded("NotEnoughItems") && GT_Mod.gregtechproxy.mHideUnusedOres;
+        tOreMetaCount = aOreMetaCount;
+        if(aOreMetaCount > 8 || aOreMetaCount < 0) aOreMetaCount = 8;
+
         for (int i = 0; i < 16; i++) {
             GT_ModHandler.addValuableOre(this, i, 1);
         }
         for (int i = 1; i < GregTech_API.sGeneratedMaterials.length; i++) {
             if (GregTech_API.sGeneratedMaterials[i] != null) {
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + i + ".name", getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 1000) + ".name", getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 2000) + ".name", getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 3000) + ".name", getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 4000) + ".name", getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 5000) + ".name", getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 6000) + ".name", getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 7000) + ".name", getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 16000) + ".name", "Small " + getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 17000) + ".name", "Small " + getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 18000) + ".name", "Small " + getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 19000) + ".name", "Small " + getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 20000) + ".name", "Small " + getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 21000) + ".name", "Small " + getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 22000) + ".name", "Small " + getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + 23000) + ".name", "Small " + getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
-                if ((GregTech_API.sGeneratedMaterials[i].mTypes & 0x8) != 0) {
-                    GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[0] != null ? this.getProcessingPrefix()[0].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i));
-                    GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[1] != null ? this.getProcessingPrefix()[1].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i + 1000));
-                    GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[2] != null ? this.getProcessingPrefix()[2].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i + 2000));
-                    GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[3] != null ? this.getProcessingPrefix()[3].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i + 3000));
-                    GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[4] != null ? this.getProcessingPrefix()[4].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i + 4000));
-                    GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[5] != null ? this.getProcessingPrefix()[5].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i + 5000));
-                    GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[6] != null ? this.getProcessingPrefix()[6].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i + 6000));
-                    GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[7] != null ? this.getProcessingPrefix()[7].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i + 7000));
-                    if (tHideOres) {
-                        if (aHideFirstMeta) codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 1000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 2000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 3000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 4000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 5000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 6000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 7000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 16000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 17000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 18000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 19000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 20000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 21000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 22000));
-                        codechicken.nei.api.API.hideItem(new ItemStack(this, 1, i + 23000));
+                for (int j = 0; j < aOreMetaCount; j++) {
+                    GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + (i + (j * 1000)) + ".name", getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
+                    GT_LanguageManager.addStringLocalization(getUnlocalizedName() + "." + ((i + 16000) + (j * 1000)) + ".name", "Small " + getLocalizedName(GregTech_API.sGeneratedMaterials[i]));
+                    if ((GregTech_API.sGeneratedMaterials[i].mTypes & 0x8) != 0) {
+                        GT_OreDictUnificator.registerOre(this.getProcessingPrefix()[j] != null ? this.getProcessingPrefix()[j].get(GregTech_API.sGeneratedMaterials[i]) : "", new ItemStack(this, 1, i + (j * 1000)));
+                        if (tHideOres) {
+                            codechicken.nei.api.API.hideItem(new ItemStack(this, 1, (j == 0 && aHideFirstMeta) ? i : i + (j * 1000)));
+                            codechicken.nei.api.API.hideItem(new ItemStack(this, 1, (i + 16000) + (j * 1000)));
+                        }
                     }
                 }
             }
@@ -162,7 +133,7 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
     }
 
     public int getHarvestLevel(int aMeta) {
-        return 2;
+        return aMeta == 5 || aMeta == 6 ? 2 : aMeta % 8;
     }
 
     public float getBlockHardness(World aWorld, int aX, int aY, int aZ) {
@@ -268,22 +239,22 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
         for (int i = 0; i < GregTech_API.sGeneratedMaterials.length; i++) {
             Materials tMaterial = GregTech_API.sGeneratedMaterials[i];
             if ((tMaterial != null) && ((tMaterial.mTypes & 0x8) != 0)) {
-                aList.add(new ItemStack(aItem, 1, i));
-                aList.add(new ItemStack(aItem, 1, i + 1000));
-                aList.add(new ItemStack(aItem, 1, i + 2000));
-                aList.add(new ItemStack(aItem, 1, i + 3000));
-                aList.add(new ItemStack(aItem, 1, i + 4000));
-                aList.add(new ItemStack(aItem, 1, i + 5000));
-                aList.add(new ItemStack(aItem, 1, i + 6000));
-                aList.add(new ItemStack(aItem, 1, i + 7000));
-                aList.add(new ItemStack(aItem, 1, i + 16000));
-                aList.add(new ItemStack(aItem, 1, i + 17000));
-                aList.add(new ItemStack(aItem, 1, i + 18000));
-                aList.add(new ItemStack(aItem, 1, i + 19000));
-                aList.add(new ItemStack(aItem, 1, i + 20000));
-                aList.add(new ItemStack(aItem, 1, i + 21000));
-                aList.add(new ItemStack(aItem, 1, i + 22000));
-                aList.add(new ItemStack(aItem, 1, i + 23000));
+                if (!(new ItemStack(aItem, 1, i).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i));
+                if (!(new ItemStack(aItem, 1, i + 1000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 1000));
+                if (!(new ItemStack(aItem, 1, i + 2000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 2000));
+                if (!(new ItemStack(aItem, 1, i + 3000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 3000));
+                if (!(new ItemStack(aItem, 1, i + 4000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 4000));
+                if (!(new ItemStack(aItem, 1, i + 5000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 5000));
+                if (!(new ItemStack(aItem, 1, i + 6000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 6000));
+                if (!(new ItemStack(aItem, 1, i + 7000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 7000));
+                if (!(new ItemStack(aItem, 1, i + 16000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 16000));
+                if (!(new ItemStack(aItem, 1, i + 17000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 17000));
+                if (!(new ItemStack(aItem, 1, i + 18000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 18000));
+                if (!(new ItemStack(aItem, 1, i + 19000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 19000));
+                if (!(new ItemStack(aItem, 1, i + 20000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 20000));
+                if (!(new ItemStack(aItem, 1, i + 21000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 21000));
+                if (!(new ItemStack(aItem, 1, i + 22000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 22000));
+                if (!(new ItemStack(aItem, 1, i + 23000).getDisplayName().contains(".name"))) aList.add(new ItemStack(aItem, 1, i + 23000));
             }
         }
     }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_GC.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_GC.java
@@ -1,0 +1,45 @@
+package gregtech.common.blocks;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+import gregtech.api.GregTech_API;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.objects.GT_CopiedBlockTexture;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.init.Blocks;
+
+public class GT_Block_Ores_GC extends GT_Block_Ores_Abstract {
+    Block aMoonBlock = GameRegistry.findBlock("GalacticraftCore", "tile.moonBlock");
+    Block aMarsBlock = GameRegistry.findBlock("GalacticraftMars", "tile.mars");
+
+    public GT_Block_Ores_GC() {
+        super("gt.blockores.gc", 4, true, Material.rock);
+    }
+
+    @Override
+    public String getUnlocalizedName() {
+        return "gt.blockores.gc";
+    }
+
+    @Override
+    public OrePrefixes[] getProcessingPrefix() { //Must have 8 entries.
+        return new OrePrefixes[]{OrePrefixes.ore, OrePrefixes.ore, OrePrefixes.ore, OrePrefixes.ore, OrePrefixes.ore, OrePrefixes.ore, OrePrefixes.ore, OrePrefixes.ore};
+    }
+
+    @Override
+    public Block getDroppedBlock() {
+        return GregTech_API.sBlockOresGC;
+    }
+
+    @Override
+    public Materials[] getDroppedDusts() { //Must have 8 entries; can be null.
+        return new Materials[]{Materials.Stone, Materials.Stone, Materials.Stone, Materials.Stone, Materials.Stone, Materials.Stone, Materials.Stone, Materials.Stone};
+    }
+
+    @Override
+    public ITexture[] getTextureSet() { //Must have 16 entries.
+        return new ITexture[]{new GT_CopiedBlockTexture(aMoonBlock, 0, 3), new GT_CopiedBlockTexture(aMoonBlock, 0, 4), new GT_CopiedBlockTexture(aMoonBlock, 0, 6), new GT_CopiedBlockTexture(aMarsBlock, 0, 9), new GT_CopiedBlockTexture(Blocks.stone, 0, 0), new GT_CopiedBlockTexture(Blocks.stone, 0, 0), new GT_CopiedBlockTexture(Blocks.stone, 0, 0), new GT_CopiedBlockTexture(Blocks.stone, 0, 0),new GT_CopiedBlockTexture(aMoonBlock, 0, 3), new GT_CopiedBlockTexture(aMoonBlock, 0, 4), new GT_CopiedBlockTexture(aMoonBlock, 0, 6), new GT_CopiedBlockTexture(aMarsBlock, 0, 9), new GT_CopiedBlockTexture(Blocks.stone, 0, 0), new GT_CopiedBlockTexture(Blocks.stone, 0, 0), new GT_CopiedBlockTexture(Blocks.stone, 0, 0), new GT_CopiedBlockTexture(Blocks.stone, 0, 0)};
+    }
+}

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_GC.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_GC.java
@@ -16,6 +16,8 @@ public class GT_Block_Ores_GC extends GT_Block_Ores_Abstract {
 
     public GT_Block_Ores_GC() {
         super("gt.blockores.gc", 4, true, Material.rock);
+        if (aMoonBlock == null) aMoonBlock = Blocks.stone;
+        if (aMarsBlock == null) aMarsBlock = Blocks.stone;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB1.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB1.java
@@ -8,12 +8,14 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.objects.GT_CopiedBlockTexture;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.init.Blocks;
 
 public class GT_Block_Ores_UB1 extends GT_Block_Ores_Abstract {
     Block aUBBlock = GameRegistry.findBlock("UndergroundBiomes", "igneousStone");
 
     public GT_Block_Ores_UB1() {
-        super("gt.blockores.ub1", true, Material.rock);
+        super("gt.blockores.ub1", 8, true, Material.rock);
+        if (aUBBlock == null) aUBBlock = Blocks.stone;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB2.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB2.java
@@ -8,12 +8,14 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.objects.GT_CopiedBlockTexture;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.init.Blocks;
 
 public class GT_Block_Ores_UB2 extends GT_Block_Ores_Abstract {
     Block aUBBlock = GameRegistry.findBlock("UndergroundBiomes", "metamorphicStone");
 
     public GT_Block_Ores_UB2() {
-        super("gt.blockores.ub2", true, Material.rock);
+        super("gt.blockores.ub2", 8, true, Material.rock);
+        if (aUBBlock == null) aUBBlock = Blocks.stone;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB3.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB3.java
@@ -8,12 +8,14 @@ import gregtech.api.interfaces.ITexture;
 import gregtech.api.objects.GT_CopiedBlockTexture;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.init.Blocks;
 
 public class GT_Block_Ores_UB3 extends GT_Block_Ores_Abstract {
     Block aUBBlock = GameRegistry.findBlock("UndergroundBiomes", "sedimentaryStone");
 
     public GT_Block_Ores_UB3() {
-        super("gt.blockores.ub3", true, Material.rock);
+        super("gt.blockores.ub3", 8, true, Material.rock);
+        if (aUBBlock == null) aUBBlock = Blocks.stone;
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
@@ -65,6 +65,20 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
                     tOreBlock = GregTech_API.sBlockOresUb3;
                     aMetaData += (BlockMeta * 1000);
                 }
+            } else if (BlockName.equals("tile.moonBlock") && (BlockMeta == 3 || BlockMeta == 4)) {
+                if (GregTech_API.sBlockOresGC != null) {
+                    switch (BlockMeta) {
+                        case 3: tOreBlock = GregTech_API.sBlockOresGC; break;
+                        case 4: aMetaData += 1000; tOreBlock = GregTech_API.sBlockOresGC; break;
+                    }
+                }
+            } else if (BlockName.equals("tile.mars") && (BlockMeta == 6 || BlockMeta == 9)) {
+                if (GregTech_API.sBlockOresGC != null) {
+                    switch (BlockMeta) {
+                        case 6: aMetaData += 2000; tOreBlock = GregTech_API.sBlockOresGC; break;
+                        case 9: aMetaData += 3000; tOreBlock = GregTech_API.sBlockOresGC; break;
+                    }
+                }
             } else if (tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.netherrack)) {
                 aMetaData += 1000;
             } else if (tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.end_stone)) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
@@ -41,6 +41,7 @@ public class GT_MetaTileEntity_DieselEngine extends GT_MetaTileEntity_MultiBlock
                 "Size(WxHxD): 3x3x4, Controller (front centered)",
                 "3x3x4 of Stable Titanium Casing (hollow, Min 24!)",
                 "2x Titanium Gear Box Casing inside the Hollow Casing",
+                "8x Engine Intake Casings (around controller, Min 8!)",
                 "1x Input Hatch (one of the Casings)",
                 "1x Maintenance Hatch (one of the Casings)",
                 "1x Muffler Hatch (top middle back)",

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_Item_Block_And_Fluid.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_Item_Block_And_Fluid.java
@@ -144,6 +144,9 @@ public class GT_Loader_Item_Block_And_Fluid
             GregTech_API.sBlockOresUb2 = new GT_Block_Ores_UB2();
             GregTech_API.sBlockOresUb3 = new GT_Block_Ores_UB3();
         }
+        if(Loader.isModLoaded("GalacticraftCore") && Loader.isModLoaded("GalacticraftMars")) {
+            GregTech_API.sBlockOresGC = new GT_Block_Ores_GC();
+        }
         GregTech_API.sBlockMetal1 = new GT_Block_Metal("gt.blockmetal1", new Materials[]{
                 Materials.Adamantium,
                 Materials.Aluminium,


### PR DESCRIPTION
Adds GT ores that match the stone textures of GC Moon & Mars. Allowed a class extending GT_Block_Ores_Abstract to choose how many sets of ores should be generated.
- Fixes #593 
- Fixed broken ore harvest level. GT_Block_Ores_Abstract now sets the harvest level for all ores extending the class. This can be overridden if it's not suitable.
- Used Asteroids dimension name in GT_Worldgenerator since GC dim numbers can be changed.
