### PR TITLE
Adjust Diesel Engine tooltip to match requirements

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
@@ -39,14 +39,15 @@ public class GT_MetaTileEntity_DieselEngine extends GT_MetaTileEntity_MultiBlock
         return new String[]{
                 "Controller Block for the Large Diesel Engine",
                 "Size(WxHxD): 3x3x4, Controller (front centered)",
-                "3x3x4 of Stable Titanium Casing (hollow, Min 24!)",
+                "3x3x4 of Stable Titanium Casing (hollow, Min 16!)",
                 "2x Titanium Gear Box Casing inside the Hollow Casing",
-                "8x Engine Intake Casings (around controller, Min 8!)",
-                "1x Input Hatch (one of the Casings)",
-                "1x Maintenance Hatch (one of the Casings)",
-                "1x Muffler Hatch (top middle back)",
+                "8x Engine Intake Casings (around controller)",
+                "2x Input Hatch (one of the Casings next to a Gear Box)",
+                "1x Maintenance Hatch (one of the Casings next to a Gear Box)",
+                "1x Muffler Hatch (top middle back, next to the rear Gear Box)",
                 "1x Dynamo Hatch (back centered)",
-                "Engine Intake Casings not obstructed (only air blocks)",
+                "Engine Intake Casings not obstructed in front (only air blocks)",
+                "Supply Diesel Fuel and Lubricant to run. Supply Oxygen to boost output (optional).",
                 "2048EU/t default output, 6144EU/t boosted output"};
     }
 


### PR DESCRIPTION
16 Casings are required along the corners and edges. The Hatches may not be along a corner or edge, but may only be placed on the sides, next to a Gear Box.

Also note Diesel, Lube, and Oxygen use.