### PR TITLE
Ore harvest level rework. Fixed #730.

### DIFF
--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores.java
@@ -27,6 +27,20 @@ public class GT_Block_Ores extends GT_Block_Ores_Abstract {
     }
 
     @Override
+    public int getBaseBlockHarvestLevel(int aMeta) {
+        switch (aMeta) {
+            case 3:
+            case 4:return 3;
+            case 0:
+            case 1:
+            case 2:
+            case 5:
+            case 6:
+            default:return 0;
+        }
+    }
+
+    @Override
     public Block getDroppedBlock() {
         return GregTech_API.sBlockOres1;
     }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_Abstract.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_Abstract.java
@@ -70,6 +70,10 @@ public abstract class GT_Block_Ores_Abstract extends GT_Generic_Block implements
         }
     }
 
+    public int getBaseBlockHarvestLevel(int aMeta) {
+        return 0;
+    }
+
     public void onNeighborChange(IBlockAccess aWorld, int aX, int aY, int aZ, int aTileX, int aTileY, int aTileZ) {
         if (!FUCKING_LOCK) {
             FUCKING_LOCK = true;

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB1.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB1.java
@@ -29,6 +29,11 @@ public class GT_Block_Ores_UB1 extends GT_Block_Ores_Abstract {
     }
 
     @Override
+    public int getBaseBlockHarvestLevel(int aMeta) {
+        return aUBBlock.getHarvestLevel(aMeta);
+    }
+
+    @Override
     public Block getDroppedBlock() {
         return GregTech_API.sBlockOresUb1;
     }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB2.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB2.java
@@ -29,6 +29,11 @@ public class GT_Block_Ores_UB2 extends GT_Block_Ores_Abstract {
     }
 
     @Override
+    public int getBaseBlockHarvestLevel(int aMeta) {
+        return aUBBlock.getHarvestLevel(aMeta);
+    }
+
+    @Override
     public Block getDroppedBlock() {
         return GregTech_API.sBlockOresUb2;
     }

--- a/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB3.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Ores_UB3.java
@@ -29,6 +29,11 @@ public class GT_Block_Ores_UB3 extends GT_Block_Ores_Abstract {
     }
 
     @Override
+    public int getBaseBlockHarvestLevel(int aMeta) {
+        return aUBBlock.getHarvestLevel(aMeta);
+    }
+
+    @Override
     public Block getDroppedBlock() {
         return GregTech_API.sBlockOresUb3;
     }

--- a/src/main/java/gregtech/common/blocks/GT_Item_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Ores.java
@@ -27,7 +27,7 @@ public class GT_Item_Ores
     public boolean placeBlockAt(ItemStack aStack, EntityPlayer aPlayer, World aWorld, int aX, int aY, int aZ, int side, float hitX, float hitY, float hitZ, int aMeta) {
         short tDamage = (short) getDamage(aStack);
         if (tDamage > 0) {
-            if (!aWorld.setBlock(aX, aY, aZ, this.field_150939_a, GT_TileEntity_Ores.getHarvestData(tDamage), 3)) {
+            if (!aWorld.setBlock(aX, aY, aZ, this.field_150939_a, GT_TileEntity_Ores.getHarvestData(tDamage, ((GT_Block_Ores_Abstract) field_150939_a).getBaseBlockHarvestLevel(aMeta % 16000 / 1000)), 3)) {
                 return false;
             }
             GT_TileEntity_Ores tTileEntity = (GT_TileEntity_Ores) aWorld.getTileEntity(aX, aY, aZ);

--- a/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
@@ -28,11 +28,11 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
     public boolean mNatural = false;
     public boolean mBlocked = true;
 
-    public static byte getHarvestData(short aMetaData) {
+    public static byte getHarvestData(short aMetaData, int aBaseBlockHarvestLevel) {
         Materials aMaterial = GregTech_API.sGeneratedMaterials[(aMetaData % 1000)];
-        byte tByte = aMaterial == null ? 0 : (byte) Math.max((aMetaData % 16000 / 1000 == 3) || (aMetaData % 16000 / 1000 == 4) ? 3 : 0, Math.min(7, aMaterial.mToolQuality - (aMetaData < 16000 ? 0 : 1)));
+        byte tByte = aMaterial == null ? 0 : (byte) Math.max(aBaseBlockHarvestLevel, Math.min(7, aMaterial.mToolQuality - (aMetaData < 16000 ? 0 : 1)));
         if(GT_Mod.gregtechproxy.mChangeHarvestLevels ){
-            tByte = aMaterial == null ? 0 : (byte) Math.max((aMetaData % 16000 / 1000 == 3) || (aMetaData % 16000 / 1000 == 4) ? GT_Mod.gregtechproxy.mGraniteHavestLevel : 0, Math.min(GT_Mod.gregtechproxy.mMaxHarvestLevel, GT_Mod.gregtechproxy.mHarvestLevel[aMaterial.mMetaItemSubID] - (aMetaData < 16000 ? 0 : 1)));
+            tByte = aMaterial == null ? 0 : (byte) Math.max(aBaseBlockHarvestLevel, Math.min(GT_Mod.gregtechproxy.mMaxHarvestLevel, GT_Mod.gregtechproxy.mHarvestLevel[aMaterial.mMetaItemSubID] - (aMetaData < 16000 ? 0 : 1)));
         }
         return tByte;
     }
@@ -107,7 +107,7 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
             } else if (!tBlock.isReplaceableOreGen(aWorld, aX, aY, aZ, Blocks.stone)) {
                 return false;
             }
-            aWorld.setBlock(aX, aY, aZ, tOreBlock, getHarvestData((short) aMetaData), 0);
+            aWorld.setBlock(aX, aY, aZ, tOreBlock, getHarvestData((short) aMetaData, ((GT_Block_Ores_Abstract) tOreBlock).getBaseBlockHarvestLevel(aMetaData % 16000 / 1000)), 0);
             TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
             if ((tTileEntity instanceof GT_TileEntity_Ores)) {
                 ((GT_TileEntity_Ores) tTileEntity).mMetaData = ((short) aMetaData);
@@ -173,7 +173,7 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
                     this.mMetaData = ((short) (this.mMetaData + 5000));
                 }
             }
-            this.worldObj.setBlockMetadataWithNotify(this.xCoord, this.yCoord, this.zCoord, getHarvestData(this.mMetaData), 0);
+            this.worldObj.setBlockMetadataWithNotify(this.xCoord, this.yCoord, this.zCoord, getHarvestData(this.mMetaData, ((GT_Block_Ores_Abstract) blockType).getBaseBlockHarvestLevel(mMetaData % 16000 / 1000)), 0);
     }
 
     public void convertOreBlock(World aWorld, int aX, int aY, int aZ) {
@@ -182,7 +182,7 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if (tTileEntity instanceof GT_TileEntity_Ores) {
             ((GT_TileEntity_Ores) tTileEntity).mMetaData = aMeta;
-            this.worldObj.setBlockMetadataWithNotify(this.xCoord, this.yCoord, this.zCoord, getHarvestData(aMeta), 0);
+            this.worldObj.setBlockMetadataWithNotify(this.xCoord, this.yCoord, this.zCoord, getHarvestData(aMeta, ((GT_Block_Ores_Abstract) tTileEntity.blockType).getBaseBlockHarvestLevel(aMeta % 16000 / 1000)), 0);
         }
     }
 


### PR DESCRIPTION
Additional parameter in getHarvestData needed because UndergroundBiomes metadata was intersected with gregtech granite and cause bugs like #730. Now possible to add more ore blocks with no metadata intersections.