### PR TITLE
Fix #785 - Unlimited EU in Dynamo Hatch

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_MultiBlockBase.java
@@ -491,7 +491,7 @@ public abstract class GT_MetaTileEntity_MultiBlockBase extends MetaTileEntity {
         if (aEU <= 0) return true;
         for (GT_MetaTileEntity_Hatch_Dynamo tHatch : mDynamoHatches) {
             if (isValidMetaTileEntity(tHatch)) {
-                if (tHatch.getBaseMetaTileEntity().increaseStoredEnergyUnits(aEU, true)) {
+                if (tHatch.getBaseMetaTileEntity().increaseStoredEnergyUnits(aEU, false)) {
                     return true;
                 }
             }


### PR DESCRIPTION
I went with @Techlone's simple solution after all.

Counting out the individual EU might make more sense if any of the multiblocks could have more than one dynamo hatch, but they don't, so this is just fine.