### PR TITLE
Don't allow Large Turbine to start up without Dynamo Hatch

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeTurbine.java
@@ -94,6 +94,8 @@ public abstract class GT_MetaTileEntity_LargeTurbine extends GT_MetaTileEntity_M
                 } else {
                     return false;
                 }
+            } else {
+                return false;
             }
         } else {
             return false;


### PR DESCRIPTION
Large Turbine was incomplete if the Dynamo Hatch spot was taken up by a different GTTE, but not if that spot was just Air or some other block.