### PR TITLE
Crash with Modular Exoskeleton #769

### DIFF
--- a/src/main/java/gregtech/common/items/armor/ArmorData.java
+++ b/src/main/java/gregtech/common/items/armor/ArmorData.java
@@ -258,11 +258,71 @@ public class ArmorData {
 		}
 		if (helmet != null && chestplate != null && leggings != null && boots != null) {
 			set(mBStat, StatType.FULLARMOR, true);
+			boolean helmHasFullRadiationDefence=false;			
+			boolean chestplateHasFullRadiationDefence=false;
+			boolean leggingsHasFullRadiationDefence=false;
+			boolean bootsHasFullRadiationDefence=false;
+			
+			boolean helmHasFullElectricalDefenceDefence=false;
+			boolean chestplateHasFullElectricalDefenceDefence=false;
+			boolean leggingsHasFullElectricalDefenceDefence=false;
+			boolean bootsHasFullElectricalDefenceDefence=false;
+			//Check each armor pieces for valid mStat value and verify that the Hash contains the StatType key
+			if(helmet.mStat!= null)
+			{
+				if(helmet.mStat.containsKey(StatType.RADIATIONDEFENCE))
+				{
+					helmHasFullRadiationDefence = helmet.mStat.get(StatType.RADIATIONDEFENCE)> 0.9f;
+				}
+				if(helmet.mStat.containsKey(StatType.ELECTRICALDEFENCE))
+				{
+					helmHasFullElectricalDefenceDefence = helmet.mStat.get(StatType.RADIATIONDEFENCE)> 0.9f;
+				}
+			}
+			if(chestplate.mStat!= null)
+			{
+				if(chestplate.mStat.containsKey(StatType.RADIATIONDEFENCE))
+				{
+					chestplateHasFullRadiationDefence = chestplate.mStat.get(StatType.RADIATIONDEFENCE)> 0.9f;
+				}
+				if(chestplate.mStat.containsKey(StatType.ELECTRICALDEFENCE))
+				{
+					chestplateHasFullElectricalDefenceDefence = chestplate.mStat.get(StatType.RADIATIONDEFENCE)> 0.9f;
+				}
+			}
+			if(leggings.mStat!= null)
+			{
+				if(leggings.mStat.containsKey(StatType.RADIATIONDEFENCE))
+				{
+					leggingsHasFullRadiationDefence = leggings.mStat.get(StatType.RADIATIONDEFENCE)> 0.9f;
+				}
+				if(leggings.mStat.containsKey(StatType.ELECTRICALDEFENCE))
+				{
+					leggingsHasFullElectricalDefenceDefence = leggings.mStat.get(StatType.RADIATIONDEFENCE)> 0.9f;
+				}
+			}
+			if(boots.mStat!= null)
+			{
+				if(boots.mStat.containsKey(StatType.RADIATIONDEFENCE))
+				{
+					bootsHasFullRadiationDefence = boots.mStat.get(StatType.RADIATIONDEFENCE)> 0.9f;
+				}
+				if(boots.mStat.containsKey(StatType.ELECTRICALDEFENCE))
+				{
+					bootsHasFullElectricalDefenceDefence = boots.mStat.get(StatType.RADIATIONDEFENCE)> 0.9f;
+				}
+			}
+			//Set Status of Full Armor types
+			set(mBStat, StatType.FULLRADIATIONARMOR, helmHasFullRadiationDefence&&chestplateHasFullRadiationDefence&&leggingsHasFullRadiationDefence &&bootsHasFullRadiationDefence);
+			set(mBStat, StatType.FULLELECTRICARMOR, helmHasFullElectricalDefenceDefence&&chestplateHasFullElectricalDefenceDefence&&leggingsHasFullElectricalDefenceDefence &&bootsHasFullElectricalDefenceDefence);	
 		} else {
+			//Reset Full armor type status to false for all types if StatType.FULLARMOR is false
 			set(mBStat, StatType.FULLARMOR, false);
+			set(mBStat, StatType.FULLRADIATIONARMOR, false);
+			set(mBStat, StatType.FULLELECTRICARMOR, false);
 		}
-		set(mBStat, StatType.FULLRADIATIONARMOR, mBStat.get(StatType.FULLARMOR) && helmet.mStat.get(StatType.RADIATIONDEFENCE) > 0.9f && chestplate.mStat.get(StatType.RADIATIONDEFENCE) > 0.9f && leggings.mStat.get(StatType.RADIATIONDEFENCE) > 0.9f && boots.mStat.get(StatType.RADIATIONDEFENCE) > 0.9f);
-		set(mBStat, StatType.FULLELECTRICARMOR, mBStat.get(StatType.FULLARMOR) && chestplate.mStat.get(StatType.ELECTRICALDEFENCE) > 0.9f && chestplate.mStat.get(StatType.ELECTRICALDEFENCE) > 0.9f && leggings.mStat.get(StatType.ELECTRICALDEFENCE) > 0.9f && boots.mStat.get(StatType.ELECTRICALDEFENCE) > 0.9f);
+		
+		
 		set(mBStat, StatType.MAGNET, 0);
 		set(mBStat, StatType.THORNS, 0);
 		set(mBStat, StatType.PROCESSINGPOWER, 0);
@@ -273,24 +333,15 @@ public class ArmorData {
 		}
 		if (chestplate != null) {
 			updateArmorStats(chestplate,updateArmorStatTypeList );
-//			change(mStat, StatType.MAGNET, chestplate.mStat.get(StatType.MAGNET));
-//			change(mStat, StatType.THORNS, chestplate.mStat.get(StatType.THORNS));
-//			change(mStat, StatType.PROCESSINGPOWER, chestplate.mStat.get(StatType.PROCESSINGPOWER));
-//			change(mStat, StatType.PROCESSINGPOWERUSED, chestplate.mStat.get(StatType.PROCESSINGPOWERUSED));
+
 		}
 		if (leggings != null) {
 			updateArmorStats(leggings,updateArmorStatTypeList );
-//			change(mStat, StatType.MAGNET, leggings.mStat.get(StatType.MAGNET));
-//			change(mStat, StatType.THORNS, leggings.mStat.get(StatType.THORNS));
-//			change(mStat, StatType.PROCESSINGPOWER, leggings.mStat.get(StatType.PROCESSINGPOWER));
-//			change(mStat, StatType.PROCESSINGPOWERUSED, leggings.mStat.get(StatType.PROCESSINGPOWERUSED));
+
 		}
 		if (boots != null) {
 			updateArmorStats(boots,updateArmorStatTypeList );
-//			change(mStat, StatType.MAGNET, boots.mStat.get(StatType.MAGNET));
-//			change(mStat, StatType.THORNS, boots.mStat.get(StatType.THORNS));
-//			change(mStat, StatType.PROCESSINGPOWER, boots.mStat.get(StatType.PROCESSINGPOWER));
-//			change(mStat, StatType.PROCESSINGPOWERUSED, boots.mStat.get(StatType.PROCESSINGPOWERUSED));
+
 		}
 		isTopItem = false;
 		if (type == 0) {

--- a/src/main/java/gregtech/common/items/armor/ArmorData.java
+++ b/src/main/java/gregtech/common/items/armor/ArmorData.java
@@ -43,7 +43,7 @@ public class ArmorData {
 
 	public Map<StatType,Float> mStat = new HashMap<StatType,Float>();
 	public Map<StatType,Boolean> mBStat = new HashMap<StatType,Boolean>();
-
+	static ArrayList<StatType> updateArmorStatTypeList;
 //	public boolean fullArmor;
 //	public boolean fullRadiationDef;
 //	public boolean fullElectricDef;
@@ -94,6 +94,14 @@ public class ArmorData {
 //	public int antiGravMaxWeight;
 
 	public ArmorData(EntityPlayer player, ItemStack stack, int type, int tier) {
+		if(updateArmorStatTypeList == null)
+		{
+			updateArmorStatTypeList = new ArrayList<StatType>();
+			updateArmorStatTypeList.add(StatType.MAGNET);
+			updateArmorStatTypeList.add(StatType.THORNS);
+			updateArmorStatTypeList.add(StatType.PROCESSINGPOWER);
+			updateArmorStatTypeList.add(StatType.PROCESSINGPOWERUSED);
+		}
 		this.type = type;
 		this.armorTier = tier;
 		ContainerModularArmor tmp = new ContainerBasicArmor((EntityPlayer) player, new InventoryArmor(ModularArmor_Item.class, stack));
@@ -259,29 +267,30 @@ public class ArmorData {
 		set(mBStat, StatType.THORNS, 0);
 		set(mBStat, StatType.PROCESSINGPOWER, 0);
 		set(mBStat, StatType.PROCESSINGPOWERUSED, 0);
-		if (helmet != null) {
-			change(mStat, StatType.MAGNET, helmet.mStat.get(StatType.MAGNET));
-			change(mStat, StatType.THORNS, helmet.mStat.get(StatType.THORNS));
-			change(mStat, StatType.PROCESSINGPOWER, helmet.mStat.get(StatType.PROCESSINGPOWER));
-			change(mStat, StatType.PROCESSINGPOWERUSED, helmet.mStat.get(StatType.PROCESSINGPOWERUSED));
+		
+		if (helmet != null) {			
+			updateArmorStats(helmet,updateArmorStatTypeList );
 		}
 		if (chestplate != null) {
-			change(mStat, StatType.MAGNET, chestplate.mStat.get(StatType.MAGNET));
-			change(mStat, StatType.THORNS, chestplate.mStat.get(StatType.THORNS));
-			change(mStat, StatType.PROCESSINGPOWER, chestplate.mStat.get(StatType.PROCESSINGPOWER));
-			change(mStat, StatType.PROCESSINGPOWERUSED, chestplate.mStat.get(StatType.PROCESSINGPOWERUSED));
+			updateArmorStats(chestplate,updateArmorStatTypeList );
+//			change(mStat, StatType.MAGNET, chestplate.mStat.get(StatType.MAGNET));
+//			change(mStat, StatType.THORNS, chestplate.mStat.get(StatType.THORNS));
+//			change(mStat, StatType.PROCESSINGPOWER, chestplate.mStat.get(StatType.PROCESSINGPOWER));
+//			change(mStat, StatType.PROCESSINGPOWERUSED, chestplate.mStat.get(StatType.PROCESSINGPOWERUSED));
 		}
 		if (leggings != null) {
-			change(mStat, StatType.MAGNET, leggings.mStat.get(StatType.MAGNET));
-			change(mStat, StatType.THORNS, leggings.mStat.get(StatType.THORNS));
-			change(mStat, StatType.PROCESSINGPOWER, leggings.mStat.get(StatType.PROCESSINGPOWER));
-			change(mStat, StatType.PROCESSINGPOWERUSED, leggings.mStat.get(StatType.PROCESSINGPOWERUSED));
+			updateArmorStats(leggings,updateArmorStatTypeList );
+//			change(mStat, StatType.MAGNET, leggings.mStat.get(StatType.MAGNET));
+//			change(mStat, StatType.THORNS, leggings.mStat.get(StatType.THORNS));
+//			change(mStat, StatType.PROCESSINGPOWER, leggings.mStat.get(StatType.PROCESSINGPOWER));
+//			change(mStat, StatType.PROCESSINGPOWERUSED, leggings.mStat.get(StatType.PROCESSINGPOWERUSED));
 		}
 		if (boots != null) {
-			change(mStat, StatType.MAGNET, boots.mStat.get(StatType.MAGNET));
-			change(mStat, StatType.THORNS, boots.mStat.get(StatType.THORNS));
-			change(mStat, StatType.PROCESSINGPOWER, boots.mStat.get(StatType.PROCESSINGPOWER));
-			change(mStat, StatType.PROCESSINGPOWERUSED, boots.mStat.get(StatType.PROCESSINGPOWERUSED));
+			updateArmorStats(boots,updateArmorStatTypeList );
+//			change(mStat, StatType.MAGNET, boots.mStat.get(StatType.MAGNET));
+//			change(mStat, StatType.THORNS, boots.mStat.get(StatType.THORNS));
+//			change(mStat, StatType.PROCESSINGPOWER, boots.mStat.get(StatType.PROCESSINGPOWER));
+//			change(mStat, StatType.PROCESSINGPOWERUSED, boots.mStat.get(StatType.PROCESSINGPOWERUSED));
 		}
 		isTopItem = false;
 		if (type == 0) {
@@ -305,6 +314,23 @@ public class ArmorData {
 		if (boots != null) {
 			maxWeight += boots.mStat.get(StatType.WEIGHT);
 		}
+	}
+
+	private void updateArmorStats(ArmorData armorData, ArrayList<StatType> statTypes) {
+		for (StatType statType : statTypes) {
+			if(armorData == null || armorData.mStat == null || !armorData.mStat.containsKey(statType))
+				continue;
+//			if(armorData != null && armorData.mStat != null && armorData.mStat.containsKey(statType))
+//			{
+				change(mStat, statType, armorData.mStat.get(statType));
+//			}
+			/*change(mStat, StatType.MAGNET, armorData.mStat.get(StatType.MAGNET));
+			change(mStat, StatType.THORNS, armorData.mStat.get(StatType.THORNS));
+			change(mStat, StatType.PROCESSINGPOWER, armorData.mStat.get(StatType.PROCESSINGPOWER));
+			change(mStat, StatType.PROCESSINGPOWERUSED, armorData.mStat.get(StatType.PROCESSINGPOWERUSED));*/			
+		}
+		
+		
 	}
 	
 	public void set(Map aMap, StatType aType, boolean aSet){

--- a/src/main/java/gregtech/common/items/armor/ArmorData.java
+++ b/src/main/java/gregtech/common/items/armor/ArmorData.java
@@ -373,7 +373,7 @@ public class ArmorData {
 				continue;
 //			if(armorData != null && armorData.mStat != null && armorData.mStat.containsKey(statType))
 //			{
-				change(mStat, statType, armorData.mStat.get(statType));
+				set(mStat, statType, armorData.mStat.get(statType));
 //			}
 			/*change(mStat, StatType.MAGNET, armorData.mStat.get(StatType.MAGNET));
 			change(mStat, StatType.THORNS, armorData.mStat.get(StatType.THORNS));

--- a/src/main/java/gregtech/common/items/armor/ArmorData.java
+++ b/src/main/java/gregtech/common/items/armor/ArmorData.java
@@ -397,7 +397,9 @@ public class ArmorData {
 	public void change(Map aMap, StatType aType, float aChange){
 		float tChange = 0;
 		if(aMap==null)System.out.println("changeMapnull");
-		if(aMap.containsKey(aType)){tChange = (float) aMap.get(aType);
+		if(aMap.containsKey(aType)){
+			Object value = aMap.get(aType);
+			tChange = value != null ? (float) aMap.get(aType) : 0.0f;
 		aMap.remove(aType);
 		}
 		aMap.put(aType, (tChange + aChange));		

--- a/src/main/java/gregtech/common/items/armor/ModularArmor_Item.java
+++ b/src/main/java/gregtech/common/items/armor/ModularArmor_Item.java
@@ -210,8 +210,8 @@ public class ModularArmor_Item extends ItemArmor implements ISpecialArmor, IGogg
 		}
 
 		// Breathing
-		if (data.type == 0 && aPlayer.getAir() < 100) {
-			int air = 0;
+		if (data.type == 0 && aPlayer.getAir() < 100 && data.fluid != null) {
+			int air = 0;			
 			if (data.fluid.getUnlocalizedName().equals("fluid.oxygen") && data.fluid.amount >= 150) {
 				aPlayer.setAir(aPlayer.getAir() + 150);
 				air = 150;

--- a/src/main/java/gregtech/common/items/armor/gui/GuiElectricArmor1.java
+++ b/src/main/java/gregtech/common/items/armor/gui/GuiElectricArmor1.java
@@ -102,12 +102,12 @@ public class GuiElectricArmor1 extends GuiContainer {
 		default:
 			break;
 		}
-		
-		if(cont.mInvArmor.data.mStat.get(StatType.TANKCAP)>0){
+		float tankCap = cont.mInvArmor.data.mStat.containsKey(StatType.TANKCAP) ? cont.mInvArmor.data.mStat.get(StatType.TANKCAP) :0.0f;
+		if(tankCap>0){
 			drawTexturedModalRect(xStart + 94, yStart + 32, 231, 69, 16, 34);
 		}
-		
-		int bar = (int) Math.floor(18 * (cont.mInvArmor.data.mStat.get(StatType.WEIGHT)/(float)1000));
+		float weight = cont.mInvArmor.data.mStat.containsKey(StatType.WEIGHT) ? cont.mInvArmor.data.mStat.get(StatType.WEIGHT) : 0.0f;
+		int bar = (int) Math.floor(18 * (weight)/(float)1000);
 		drawTexturedModalRect(xStart + 15, yStart + 7, 217, 26, bar, 5);
 		drawTexturedModalRect(xStart + bar + 15, yStart + 7, 197+bar, 26, 18-bar, 5);
 		

--- a/src/main/java/gregtech/common/items/armor/gui/GuiElectricArmor1.java
+++ b/src/main/java/gregtech/common/items/armor/gui/GuiElectricArmor1.java
@@ -151,10 +151,15 @@ public class GuiElectricArmor1 extends GuiContainer {
 			if(tab>2){tab=0;}
 			if(tab<0){tab=2;}
 			if(xStart>72&&xStart<112){
-				if(xStart>72&&xStart<81&&cont.mInvArmor.data.helmet!=null){cont.mInvArmor.data.helmet.openGui=true;player.closeScreen();}
-				if(xStart>82&&xStart<91&&cont.mInvArmor.data.chestplate!=null){cont.mInvArmor.data.chestplate.openGui=true;player.closeScreen();}
-				if(xStart>92&&xStart<101&&cont.mInvArmor.data.leggings!=null){cont.mInvArmor.data.leggings.openGui=true;player.closeScreen();}
-				if(xStart>102&&xStart<112&&cont.mInvArmor.data.boots!=null){cont.mInvArmor.data.boots.openGui=true;player.closeScreen();}
+				if(xStart>72&&xStart<81&&cont.mInvArmor.data.helmet!=null){cont.mInvArmor.data.helmet.openGui=true;}
+				if(xStart>82&&xStart<91&&cont.mInvArmor.data.chestplate!=null){cont.mInvArmor.data.chestplate.openGui=true;}
+				if(xStart>92&&xStart<101&&cont.mInvArmor.data.leggings!=null){cont.mInvArmor.data.leggings.openGui=true;}
+				if(xStart>102&&xStart<112&&cont.mInvArmor.data.boots!=null){cont.mInvArmor.data.boots.openGui=true;}
+				
+//				if(xStart>72&&xStart<81&&cont.mInvArmor.data.helmet!=null){cont.mInvArmor.data.helmet.openGui=true;player.closeScreen();}
+//				if(xStart>82&&xStart<91&&cont.mInvArmor.data.chestplate!=null){cont.mInvArmor.data.chestplate.openGui=true;player.closeScreen();}
+//				if(xStart>92&&xStart<101&&cont.mInvArmor.data.leggings!=null){cont.mInvArmor.data.leggings.openGui=true;player.closeScreen();}
+//				if(xStart>102&&xStart<112&&cont.mInvArmor.data.boots!=null){cont.mInvArmor.data.boots.openGui=true;player.closeScreen();}
 			}
 		}
 //		Slot slot = getSlotAtPosition(mouseX, mouseY);

--- a/src/main/java/gregtech/common/items/armor/gui/GuiElectricArmor1.java
+++ b/src/main/java/gregtech/common/items/armor/gui/GuiElectricArmor1.java
@@ -1,7 +1,10 @@
 package gregtech.common.items.armor.gui;
 
+import gregtech.api.enums.GT_Values;
 import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_Utility;
+import gregtech.common.GT_Network;
+import gregtech.common.items.armor.ArmorData;
 import gregtech.common.items.armor.components.StatType;
 
 import java.text.DecimalFormat;
@@ -168,27 +171,39 @@ public class GuiElectricArmor1 extends GuiContainer {
 			}
 		}
 //		Slot slot = getSlotAtPosition(mouseX, mouseY);
-//		if (slot != null && slot instanceof SlotFluid && player != null) {
+//		if (slot != null && slot instanceof SlotFluid && player != null && cont.mInvArmor.data.helmet!=null) {
 //			ItemStack tmp = player.inventory.getItemStack();
+//			//GT_Network gtn = new GT_Network();
 //			if (tmp == null) {
-//				GTExtras.NET.sendToServer(new FluidSync(player.getCommandSenderName(), 0, "null"));
+//				//GT_Values.NW.sendToServer(new FluidSync(player.getCommandSenderName(), 0, "null"));				
 //			}
+//			//ArmorData armorData = new ArmorData(player,);
 //			if (tmp != null && tmp.getItem() instanceof IFluidContainerItem) {
 //				FluidStack tmp2 = ((IFluidContainerItem) tmp.getItem()).getFluid(tmp);
 //				if (!slot.getHasStack() && tmp2 != null) {
-//					slot.putStack(UT.Fluids.display(tmp2, true));
-//					GTExtras.NET.sendToServer(new FluidSync(player.getCommandSenderName(), tmp2.amount, UT.Fluids.name(tmp2, false)));
-//					ItemStack tmp4 = UT.Fluids.getContainerForFilledItem(tmp, true);
+//					slot.putStack(GT_Utility.getFluidDisplayStack(tmp2, true));					
+//					
+//					if(cont.mInvArmor.data.helmet.fluid == null)
+//					{
+//						cont.mInvArmor.data.helmet.fluid = new FluidStack(tmp2.getFluid(), tmp2.amount);
+//					}
+//					else
+//					{
+//						cont.mInvArmor.data.helmet.fluid.amount += tmp2.amount;
+//					}
+//					
+//					//GT_Values.NW.sendToServer(new FluidSync(player.getCommandSenderName(), tmp2.amount, GT_Utility.getFluidName(tmp2, false)));
+//					ItemStack tmp4 = GT_Utility.getContainerForFilledItem(tmp, true);					
 //					tmp4.stackSize = 1;
 //					if (tmp.stackSize > 1) {
 //						player.inventory.addItemStackToInventory(tmp4);
 //						tmp.stackSize--;
 //						player.inventory.setItemStack(tmp);
-//						GTExtras.NET.sendToServer(new FluidSync2(player.getCommandSenderName()));
+//						//GT_Values.NW.sendToServer(new FluidSync2(player.getCommandSenderName()));
 //					} else {
 //						player.inventory.setItemStack(null);
 //						player.inventory.addItemStackToInventory(tmp4);
-//						GTExtras.NET.sendToServer(new FluidSync2(player.getCommandSenderName()));
+//						//GT_Values.NW.sendToServer(new FluidSync2(player.getCommandSenderName()));
 //					}
 //
 //				} else if (slot.getHasStack() && tmp2 != null) {
@@ -204,9 +219,17 @@ public class GuiElectricArmor1 extends GuiContainer {
 //								tmp3.stackSize--;
 //							}
 //							player.inventory.setItemStack(tmp3);
-//							GTExtras.NET.sendToServer(new FluidSync2(player.getCommandSenderName()));
-//							slot.putStack(UT.Fluids.display(tmp2, true));
-//							GTExtras.NET.sendToServer(new FluidSync(player.getCommandSenderName(), tmp2.amount, UT.Fluids.name(tmp2, false)));
+//							//GT_Values.NW.sendToServer(new FluidSync2(player.getCommandSenderName()));
+//							slot.putStack(GT_Utility.getFluidDisplayStack(tmp2, true));
+//							if(cont.mInvArmor.data.helmet.fluid == null)
+//							{
+//								cont.mInvArmor.data.helmet.fluid = new FluidStack(tmp2.getFluid(), tmp2.amount);
+//							}
+//							else
+//							{
+//								cont.mInvArmor.data.helmet.fluid.amount += tmp2.amount;
+//							}
+//							//GT_Values.NW.sendToServer(new FluidSync(player.getCommandSenderName(), tmp2.amount, GT_Utility.getFluidName(tmp2, false)));
 //						}
 //					}
 //				}

--- a/src/main/java/gregtech/common/items/armor/gui/GuiElectricArmor1.java
+++ b/src/main/java/gregtech/common/items/armor/gui/GuiElectricArmor1.java
@@ -40,7 +40,12 @@ public class GuiElectricArmor1 extends GuiContainer {
 		cont = containerModularArmor;
 		tab = 0;
 	}
-	
+	@Override
+	public void onGuiClosed() 
+	{
+		cont.saveInventory(player);
+		super.onGuiClosed();
+	};
 	public String seperateNumber(long number){
 		DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(Locale.US);
 		DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();

--- a/src/main/java/gregtech/common/items/armor/gui/GuiModularArmor.java
+++ b/src/main/java/gregtech/common/items/armor/gui/GuiModularArmor.java
@@ -191,10 +191,10 @@ public class GuiModularArmor extends GuiContainer {
 		int yStart = mouseY-((height - ySize) / 2);
 		if(yStart>67&&yStart<77){
 			if(xStart>124&&xStart<163){
-				if(xStart>124&&xStart<133&&cont.mInvArmor.data.helmet!=null){cont.mInvArmor.data.helmet.openGui=true;player.closeScreen();}
-				if(xStart>134&&xStart<143&&cont.mInvArmor.data.chestplate!=null){cont.mInvArmor.data.chestplate.openGui=true;player.closeScreen();}
-				if(xStart>144&&xStart<153&&cont.mInvArmor.data.leggings!=null){cont.mInvArmor.data.leggings.openGui=true;player.closeScreen();}
-				if(xStart>154&&xStart<163&&cont.mInvArmor.data.boots!=null){cont.mInvArmor.data.boots.openGui=true;player.closeScreen();}
+				if(xStart>124&&xStart<133&&cont.mInvArmor.data.helmet!=null){cont.mInvArmor.data.helmet.openGui=true;}
+				if(xStart>134&&xStart<143&&cont.mInvArmor.data.chestplate!=null){cont.mInvArmor.data.chestplate.openGui=true;}
+				if(xStart>144&&xStart<153&&cont.mInvArmor.data.leggings!=null){cont.mInvArmor.data.leggings.openGui=true;}
+				if(xStart>154&&xStart<163&&cont.mInvArmor.data.boots!=null){cont.mInvArmor.data.boots.openGui=true;}
 			}
 		}
 		super.mouseClicked(mouseX, mouseY, mouseBtn);


### PR DESCRIPTION
Fix for Crash with Modular Exoskeleton #769. Removed player.closeScreen() call in GuiElectricArmor1 and GuiModularArmor to eliminate the graphics glitch that happens when switching between Modular Armor inventory tabs.
Fixed issue with Modular Armor inventory not saving properly after removing the call to closeScreen
Added null and key checks when determining if a full radiation or electrical armor set is configured
