### PR TITLE
Fix #830 - Maint Cover does not emit if rotor needs maint

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_NeedMaintainance.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_NeedMaintainance.java
@@ -44,7 +44,8 @@ public class GT_Cover_NeedMaintainance extends GT_CoverBehavior {
                 		ItemStack tTurbine = multi.getRealInventory()[1];
                 		long tMax = GT_MetaGenerated_Tool.getToolMaxDamage(tTurbine);
                 		long tCur = GT_MetaGenerated_Tool.getToolDamage(tTurbine);
-                		if(tCur > tMax*8/10);
+                		if(tCur < tMax*2/10)
+                			needsRepair = true;
                 	}
                 	
                 }


### PR DESCRIPTION
Also change the condition back to 20% durability or less. Credit to @Techlone for eyeballing this one before the issue was even reported.