### PR TITLE
Add advanced seismic prospector

### DIFF
--- a/src/main/java/gregtech/api/enums/ItemList.java
+++ b/src/main/java/gregtech/api/enums/ItemList.java
@@ -632,7 +632,7 @@ public enum ItemList implements IItemContainer {
     Casing_Coil_Cupronickel, Casing_Coil_Kanthal, Casing_Coil_Nichrome, Casing_Coil_TungstenSteel, Casing_Coil_HSSG, Casing_Coil_Naquadah, Casing_Coil_NaquadahAlloy,
     MobRep_LV, MobRep_MV, MobRep_HV, MobRep_EV, MobRep_IV, MobRep_LuV, MobRep_ZPM, MobRep_UV, Cover_PlayerDetector, Machine_Multi_HeatExchanger,
     Block_BronzePlate, Block_IridiumTungstensteel, Block_Plascrete, Block_TungstenSteelReinforced,
-    Honeycomb, Charcoal_Pile, Block_BrittleCharcoal, Seismic_Prospector, OilDrill, AdvancedMiner2, PyrolyseOven, OilCracker, Crop_Drop_UUMBerry, Crop_Drop_UUABerry, Empty_Board_Basic, Empty_Board_Elite,
+    Honeycomb, Charcoal_Pile, Block_BrittleCharcoal, Seismic_Prospector, Seismic_Prospector_Adv, OilDrill, AdvancedMiner2, PyrolyseOven, OilCracker, Crop_Drop_UUMBerry, Crop_Drop_UUABerry, Empty_Board_Basic, Empty_Board_Elite,
     Battery_Charger_4by4_ULV, Battery_Charger_4by4_LV, Battery_Charger_4by4_MV, Battery_Charger_4by4_HV, Battery_Charger_4by4_EV, Battery_Charger_4by4_IV, Battery_Charger_4by4_LuV, Battery_Charger_4by4_ZPM, Battery_Charger_4by4_UV, Battery_Charger_4by4_MAX,
     MicroTransmitter_HV, MicroTransmitter_EV, MicroTransmitter_IV, MicroTransmitter_LUV, MicroTransmitter_ZPM,
     Crop_Drop_Bauxite, Crop_Drop_Ilmenite, Crop_Drop_Pitchblende, Crop_Drop_Uraninite, Crop_Drop_Thorium, Crop_Drop_Nickel, Crop_Drop_Zinc, Crop_Drop_Manganese, Crop_Drop_Scheelite, Crop_Drop_Platinum, Crop_Drop_Iridium, Crop_Drop_Osmium, Crop_Drop_Naquadah, Uraniumcell_1, Uraniumcell_2, Uraniumcell_4, Moxcell_1, Moxcell_2, Moxcell_4,

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_AdvSeismicProspector.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_AdvSeismicProspector.java
@@ -1,0 +1,221 @@
+package gregtech.common.tileentities.machines.basic;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import gregtech.api.GregTech_API;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.Textures;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_BasicMachine;
+import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.api.objects.ItemData;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
+import gregtech.common.blocks.GT_Block_Ores_Abstract;
+import gregtech.common.blocks.GT_TileEntity_Ores;
+import ic2.core.Ic2Items;
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.fluids.FluidStack;
+import sun.text.resources.es.CollationData_es;
+
+public class GT_MetaTileEntity_AdvSeismicProspector extends GT_MetaTileEntity_BasicMachine {    
+    boolean ready = false;
+    int radius;
+    int near;
+    int middle;
+    int step;
+
+    public GT_MetaTileEntity_AdvSeismicProspector(int aID, String aName, String aNameRegional, int aTier, int aRadius, int aStep) {
+        super(aID, aName, aNameRegional, aTier, 1, // amperage
+                "Place, activate with explosives ("
+                + "8 Glyceryl, "
+                + "32 TNT or "
+                + "16 ITNT), use Data Stick",
+                1, // input slot count
+                1, // output slot count
+                "Default.png", // GUI name
+                "", // NEI name
+                new ITexture[] { new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_SIDE_ROCK_BREAKER_ACTIVE),
+                        new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_SIDE_ROCK_BREAKER),
+                        new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_TOP_ROCK_BREAKER_ACTIVE),
+                        new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_TOP_ROCK_BREAKER),
+                        new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_FRONT_ROCK_BREAKER_ACTIVE),
+                        new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_FRONT_ROCK_BREAKER),
+                        new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_BOTTOM_ROCK_BREAKER_ACTIVE),
+                        new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_BOTTOM_ROCK_BREAKER) });
+        radius = aRadius;
+        near = radius / 3;
+        near = near + near % 2; // making near value even;
+        middle = near * 2;
+        step = aStep;
+    }
+
+    protected GT_MetaTileEntity_AdvSeismicProspector(String aName, int aTier, String aDescription, ITexture[][][] aTextures,
+            String aGUIName, String aNEIName, int aNear, int aMiddle, int aRadius, int aStep) {
+        super(aName, aTier, 1, aDescription, aTextures, 1, 1, aGUIName, aNEIName);
+        radius = aRadius;
+        near = aNear;
+        middle = aMiddle;
+        step = aStep;
+    }
+
+    public MetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new GT_MetaTileEntity_AdvSeismicProspector(this.mName, this.mTier, this.mDescription, this.mTextures,
+                this.mGUIName, this.mNEIName, this.near, this.middle, this.radius, this.step);
+    }
+
+    @Override
+    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
+        if (aBaseMetaTileEntity.isServerSide()) {
+            ItemStack aStack = aPlayer.getCurrentEquippedItem();
+
+            if (!ready && (GT_Utility.consumeItems(aPlayer, aStack, Item.getItemFromBlock(Blocks.tnt), 32)
+                    || GT_Utility.consumeItems(aPlayer, aStack, Ic2Items.industrialTnt.getItem(), 16)
+                    || GT_Utility.consumeItems(aPlayer, aStack, Materials.Glyceryl, 8))) {
+
+                this.ready = true;
+                this.mMaxProgresstime = (aPlayer.capabilities.isCreativeMode ? 20 : 800);
+
+            } else if (ready && mMaxProgresstime == 0
+                    && aStack != null && aStack.stackSize == 1
+                    && aStack.getItem() == ItemList.Tool_DataStick.getItem()) {
+                this.ready = false;
+
+                // prospecting ores
+                HashMap<String, Integer> tNearOres = new HashMap<String, Integer>();
+                HashMap<String, Integer> tMiddleOres = new HashMap<String, Integer>();
+                HashMap<String, Integer> tFarOres = new HashMap<String, Integer>();
+                prospectOres(tNearOres, tMiddleOres, tFarOres);
+
+                // prospecting oils
+                HashMap<String, Integer> tOils = new HashMap<String, Integer>(9);
+                prospectOils(tOils);
+
+                GT_Utility.ItemNBT.setAdvancedProspectionData(mTier,
+                    aStack,
+                    this.getBaseMetaTileEntity().getXCoord(),
+                    this.getBaseMetaTileEntity().getYCoord(),
+                    this.getBaseMetaTileEntity().getZCoord(),
+                    this.getBaseMetaTileEntity().getWorld().provider.dimensionId,
+                    GT_Utility.sortByValueToList(tOils),
+                    GT_Utility.sortByValueToList(tNearOres),
+                    GT_Utility.sortByValueToList(tMiddleOres),
+                    GT_Utility.sortByValueToList(tFarOres),
+                    near, middle, radius);
+            }
+        }
+
+        return true;
+    }
+
+    private void prospectOils(HashMap<String, Integer> aOils) {
+
+        int tLeftXBound = this.getBaseMetaTileEntity().getXCoord() - radius;
+        int tRightXBound = tLeftXBound + 2*radius;
+
+        int tLeftZBound = this.getBaseMetaTileEntity().getZCoord() - radius;
+        int tRightZBound = tLeftZBound + 2*radius;
+
+        ArrayList<String> filterList = new ArrayList<String>(9);
+        String filter;
+
+        for (int x = tLeftXBound; x <= tRightXBound; ++x)
+            for (int z = tLeftZBound; z <= tRightZBound; ++z) {
+                filter = x/96 + "," + z/96;
+
+                if (!filterList.contains(filter)) {
+                    filterList.add(filter);
+
+                    putOil((x/96)*96, (z/96)*96, aOils);
+                }
+            }
+    }
+
+    private void putOil(int x, int z, HashMap<String, Integer> aOils) {
+        FluidStack tFluid = GT_Utility.getUndergroundOil(getBaseMetaTileEntity().getWorld(), x, z);
+        if (tFluid.amount / 5000 > 0)
+            aOils.put(x + "," + z + "," + (tFluid.amount / 5000) + "," + tFluid.getLocalizedName(), tFluid.amount / 5000);
+    }
+
+    private void prospectOres(Map<String, Integer> aNearOres, Map<String, Integer> aMiddleOres, Map<String, Integer> aFarOres) {        
+        int tLeftXBound = this.getBaseMetaTileEntity().getXCoord() - radius;
+        int tRightXBound = tLeftXBound + 2*radius;
+
+        int tLeftZBound = this.getBaseMetaTileEntity().getZCoord() - radius;
+        int tRightZBound = tLeftZBound + 2*radius;
+
+        for (int i = tLeftXBound; i <= tRightXBound; i += step)
+            for (int k = tLeftZBound; k <= tRightZBound; k += step) {
+                int di = Math.abs(i - this.getBaseMetaTileEntity().getXCoord());
+                int dk = Math.abs(k - this.getBaseMetaTileEntity().getZCoord());
+
+                if (di <= near && dk <= near)
+                    prospectHole(i, k, aNearOres);
+                else if (di <= middle && dk <= middle)
+                    prospectHole(i, k, aMiddleOres);
+                else
+                    prospectHole(i, k, aFarOres);
+            } 
+    }
+
+    private void prospectHole(
+            int i, int k, Map<String, Integer> aOres) {
+
+        String tFoundOre = null;
+        for (int j = this.getBaseMetaTileEntity().getYCoord(); j > 0; j--) {
+            tFoundOre = checkForOre(i, j, k);                            
+            if (tFoundOre == null)
+                continue;
+
+            countOre(aOres, tFoundOre);
+        }
+    }
+
+    private String checkForOre(int x, int y, int z) {
+        Block tBlock = this.getBaseMetaTileEntity().getBlock(x, y, z);
+
+        if (tBlock instanceof GT_Block_Ores_Abstract) {
+            TileEntity tTileEntity = getBaseMetaTileEntity().getWorld().getTileEntity(x, y, z);
+
+            if ((tTileEntity instanceof GT_TileEntity_Ores)
+                && (((GT_TileEntity_Ores) tTileEntity).mMetaData < 16000)) { // Filtering small ores
+                Materials tMaterial
+                    = GregTech_API.sGeneratedMaterials[((GT_TileEntity_Ores) tTileEntity).mMetaData % 1000];
+
+                if ((tMaterial != null) && (tMaterial != Materials._NULL))
+                    return tMaterial.mDefaultLocalName;
+            }
+        } else {
+            int tMetaID = getBaseMetaTileEntity().getWorld().getBlockMetadata(x, y, z);
+            ItemData tAssotiation = GT_OreDictUnificator.getAssociation(new ItemStack(tBlock, 1, tMetaID));
+
+            if ((tAssotiation != null) && (tAssotiation.mPrefix.toString().startsWith("ore")))
+                return tAssotiation.mMaterial.mMaterial.mDefaultLocalName;
+        }
+
+        return null;
+    }
+
+    private static void countOre(Map<String, Integer> map, String ore) {
+        Integer oldCount = map.get(ore);
+        oldCount = (oldCount == null) ? 0 : oldCount;
+
+        map.put(ore, oldCount + 1);
+    }
+}

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -1201,7 +1201,9 @@ public class GT_Loader_MetaTileEntities implements Runnable {
         GT_ModHandler.addCraftingRecipe(ItemList.Charcoal_Pile.get(1L, new Object[0]), bitsd, new Object[]{"EME", "CCC", 'M', ItemList.Hull_Bronze_Bricks, 'E', OrePrefixes.nugget.get(Materials.WroughtIron), 'C', new ItemStack(Items.flint, 1)});
 
         ItemList.Seismic_Prospector.set(new GT_MetaTileEntity_SeismicProspector(1156, "basicmachine.seismicprospector", "Seismic Prospector", 1).getStackForm(1));
+        ItemList.Seismic_Prospector_Adv.set(new GT_MetaTileEntity_AdvSeismicProspector(1173, "basicmachine.seismicprospector.3", "Advanced Seismic Prospector", 4, 95, 4).getStackForm(1));
         GT_ModHandler.addCraftingRecipe(ItemList.Seismic_Prospector.get(1L, new Object[0]), bitsd, new Object[]{"WWW", "EME", "CCC", 'M', ItemList.Hull_Steel, 'W', OrePrefixes.plateDouble.get(Materials.Steel), 'E', OrePrefixes.circuit.get(Materials.Basic), 'C', ItemList.Sensor_LV});
+        GT_ModHandler.addCraftingRecipe(ItemList.Seismic_Prospector_Adv.get(1L, new Object[0]), bitsd, new Object[] { "WWW", "EME", "CCC", 'M', ItemList.Hull_EV, 'W', OrePrefixes.plateDouble.get(Materials.VanadiumSteel),'E', OrePrefixes.circuit.get(Materials.Data), 'C', ItemList.Sensor_EV });
 
         ItemList.OilDrill.set(new GT_MetaTileEntity_OilDrill(1157, "multimachine.oildrill", "Oil Drilling Rig").getStackForm(1));
         GT_ModHandler.addCraftingRecipe(ItemList.OilDrill.get(1L, new Object[0]), bitsd, new Object[]{"WWW", "EME", "CCC", 'M', ItemList.Hull_MV, 'W', OrePrefixes.frameGt.get(Materials.Steel), 'E', OrePrefixes.circuit.get(Materials.Good), 'C', ItemList.Electric_Motor_MV});


### PR DESCRIPTION
Higher tier seismic prospector for high-middle game ore prospecting (just before tungstate/iridium). It should help annoying prospecting for tungstate.

Scans 191*191 area from bottom to prospector level, splits found ore in three ranges (<= 32; <= 64; and farther) and sorts ore by quantity desc.

Also it does oilprospecting for all oil-chunks lay in that area.

I've taken 1173 metatileentity ID.