### PR TITLE
1.10.2 misc fixes

### DIFF
--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -373,7 +373,6 @@ public class GregTech_API {
         GT_ItemStack stack = new GT_ItemStack(aStack);
         int coverId = stack.hashCode();
         sCoverItems.put(stack, coverId);
-        System.out.println();
         sCovers.put(coverId, aCover == null || !aCover.isValidTexture() ? Textures.BlockIcons.ERROR_RENDERING[0] : aCover);
         if (aBehavior != null) sCoverBehaviors.put(coverId, aBehavior);
     }

--- a/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
+++ b/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
@@ -712,7 +712,7 @@ public abstract class GT_MetaGenerated_Tool extends GT_MetaBase_Item implements 
     @SideOnly(Side.CLIENT)
     public int getColorFromItemStack(ItemStack stack, int tintIndex) {
         IToolStats toolStats = getToolStats(stack);
-        if(tintIndex == 1) {
+        if(tintIndex > 1) {
             short[] colorsHead = toolStats.getRGBa(true, stack);
             if(colorsHead != null)
                 return ITexture.color(colorsHead, true);

--- a/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
+++ b/src/main/java/gregtech/api/items/GT_MetaGenerated_Tool.java
@@ -511,10 +511,8 @@ public abstract class GT_MetaGenerated_Tool extends GT_MetaBase_Item implements 
     }
 
     public IToolStats getToolStats(ItemStack aStack) {
-        if(isItemStackUsable(aStack)) {
-            return getToolStatsInternal(aStack);
-        }
-        return null;
+        // if(isItemStackUsable(aStack)) { // why?
+        return getToolStatsInternal(aStack);
     }
 
     private IToolStats getToolStatsInternal(ItemStack aStack) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_Charcoal_Pit.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_Charcoal_Pit.java
@@ -11,6 +11,7 @@ import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_Recipe;
 import gregtech.common.tools.GT_Tool;
 import gregtech.common.GT_Pollution;
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -140,7 +141,7 @@ public class GT_MetaTileEntity_Charcoal_Pit extends GT_MetaTileEntity_MultiBlock
         if (aX + 1 < 6 && (isWoodLog(tBlock))) {
             if (!aList1.contains(new BlockPos(aX + 1, aY, aZ)) && (!aList2.contains(new BlockPos(aX + 1, aY, aZ))))
                 p1 = true;
-        } else if (!(tBlock == Blocks.DIRT || tBlock == Blocks.GRASS)) {
+        } else if (!isDirt(tBlock)) {
             return false;
         }
 
@@ -148,7 +149,7 @@ public class GT_MetaTileEntity_Charcoal_Pit extends GT_MetaTileEntity_MultiBlock
         if (aX - 1 > -6 && (isWoodLog(tBlock))) {
             if (!aList1.contains(new BlockPos(aX - 1, aY, aZ)) && (!aList2.contains(new BlockPos(aX - 1, aY, aZ))))
                 p2 = true;
-        } else if (!(tBlock == Blocks.DIRT || tBlock == Blocks.GRASS)) {
+        } else if (!isDirt(tBlock)) {
             return false;
         }
 
@@ -156,7 +157,7 @@ public class GT_MetaTileEntity_Charcoal_Pit extends GT_MetaTileEntity_MultiBlock
         if (aY + 1 < 1 && (isWoodLog(tBlock))) {
             if (!aList1.contains(new BlockPos(aX, aY + 1, aZ)) && (!aList2.contains(new BlockPos(aX, aY + 1, aZ))))
                 p3 = true;
-        } else if (!(tBlock == Blocks.DIRT || tBlock == Blocks.GRASS || (aX == 0 && aY == -1 && aZ == 0 && tBlock == GregTech_API.sBlockMachines))) {
+        } else if (!(isDirt(tBlock) || (aX == 0 && aY == -1 && aZ == 0 && tBlock.getBlock() == GregTech_API.sBlockMachines))) {
             return false;
         }
 
@@ -164,7 +165,7 @@ public class GT_MetaTileEntity_Charcoal_Pit extends GT_MetaTileEntity_MultiBlock
         if (aY - 1 > -6 && (isWoodLog(tBlock))) {
             if (!aList1.contains(new BlockPos(aX, aY - 1, aZ)) && (!aList2.contains(new BlockPos(aX, aY - 1, aZ))))
                 p4 = true;
-        } else if (tBlock != Blocks.BRICK_BLOCK) {
+        } else if (tBlock.getBlock() != Blocks.BRICK_BLOCK) {
             return false;
         }
 
@@ -172,7 +173,7 @@ public class GT_MetaTileEntity_Charcoal_Pit extends GT_MetaTileEntity_MultiBlock
         if (aZ + 1 < 6 && (isWoodLog(tBlock))) {
             if (!aList1.contains(new BlockPos(aX, aY, aZ + 1)) && (!aList2.contains(new BlockPos(aX, aY, aZ + 1))))
                 p5 = true;
-        } else if (!(tBlock == Blocks.DIRT || tBlock == Blocks.GRASS)) {
+        } else if (!isDirt(tBlock)) {
             return false;
         }
 
@@ -180,7 +181,7 @@ public class GT_MetaTileEntity_Charcoal_Pit extends GT_MetaTileEntity_MultiBlock
         if (aZ - 1 > -6 && (isWoodLog(tBlock))) {
             if (!aList1.contains(new BlockPos(aX, aY, aZ - 1)) && (!aList2.contains(new BlockPos(aX, aY, aZ - 1))))
                 p6 = true;
-        } else if (!(tBlock == Blocks.DIRT || tBlock == Blocks.GRASS)) {
+        } else if (!isDirt(tBlock)) {
             return false;
         }
         aList1.add(new BlockPos(aX, aY, aZ));
@@ -198,6 +199,11 @@ public class GT_MetaTileEntity_Charcoal_Pit extends GT_MetaTileEntity_MultiBlock
         return  OrePrefixes.log.contains(GT_Tool.getBlockStack(log))
                 && ((tTool != null) && (tTool.equals("axe"))) ||
                 (log.getMaterial() == Material.WOOD);
+    }
+
+    private boolean isDirt(IBlockState dirt) {
+        Block b = dirt.getBlock();
+        return (b == Blocks.DIRT || b == Blocks.GRASS);
     }
 
     public boolean checkMachine(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {


### PR DESCRIPTION
Fixes Charcoal Pile Igniter, incorrect colors on metatools, a crash when rendering a newly crafted Soldering Iron (and possibly every empty electric tool), and stops filling up the console with blank lines.