### PR TITLE
[1.10.2] Fix redstone behavior for covers

### DIFF
--- a/src/main/java/gregtech/api/interfaces/tileentity/IRedstoneEmitter.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IRedstoneEmitter.java
@@ -34,4 +34,10 @@ public interface IRedstoneEmitter extends IHasWorldObjectAndCoords {
      * Gets the Output for the comparator on the given Side
      */
     byte getComparatorValue(byte aSide);
+
+    /**
+     * Return whether the TileEntity can output redstone to the given side. Used to visually connect
+     * vanilla redstone wires.
+     */
+    boolean canOutputRedstone(byte aSide);
 }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -293,7 +293,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                             }
 
                             if (mNeedsBlockUpdate) {
-                                worldObj.notifyBlockOfStateChange(getPos(), getBlockType());
+                                worldObj.notifyNeighborsOfStateChange(getPos(), getBlockType());
                                 mNeedsBlockUpdate = false;
                             }
                         }
@@ -492,6 +492,12 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     @Override
     public boolean getRedstone(byte aSide) {
         return getInternalInputRedstoneSignal(aSide) > 0;
+    }
+
+    @Override
+    public boolean canOutputRedstone(byte aSide) {
+        return (getCoverBehaviorAtSide(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this)
+                || getCoverBehaviorAtSide(aSide).letsRedstoneGoOut(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this));
     }
 
     public ITexture getCoverTexture(byte aSide) {
@@ -1017,7 +1023,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getInputRedstoneSignal(byte aSide) {
-        return (byte) (worldObj.getRedstonePower(getPos(), EnumFacing.VALUES[aSide]) & 15);
+        return (byte) (worldObj.getRedstonePower(getPos().offset(EnumFacing.VALUES[aSide]), EnumFacing.VALUES[aSide]) & 15);
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -557,7 +557,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                             }
 
                             if (mNeedsBlockUpdate) {
-                                worldObj.notifyBlockOfStateChange(getPos(), getBlockOffset(0, 0, 0));
+                                worldObj.notifyNeighborsOfStateChange(getPos(), getBlockOffset(0, 0, 0));
                                 mNeedsBlockUpdate = false;
                             }
                         }
@@ -732,6 +732,12 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     @Override
     public boolean getRedstone(byte aSide) {
         return getInternalInputRedstoneSignal(aSide) > 0;
+    }
+
+    @Override
+    public boolean canOutputRedstone(byte aSide) {
+        return (getCoverBehaviorAtSide(aSide).manipulatesSidedRedstoneOutput(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this)
+                || getCoverBehaviorAtSide(aSide).letsRedstoneGoOut(aSide, getCoverIDAtSide(aSide), getCoverDataAtSide(aSide), this));
     }
 
     public ITexture getCoverTexture(byte aSide) {
@@ -1437,7 +1443,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public byte getInputRedstoneSignal(byte aSide) {
-        return (byte) (worldObj.getRedstonePower(getPos(), EnumFacing.VALUES[aSide]) & 15);
+        return (byte) (worldObj.getRedstonePower(getPos().offset(EnumFacing.VALUES[aSide]), EnumFacing.VALUES[aSide]) & 15);
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -137,9 +137,15 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
         return false;
     }
 
+    /**
+     * NB: Vanilla redstone behavior is that wires will connect to redstone emitters but not consumers.
+     * Thus we only say we can connect if we are an emitter. (This is usually delegated to a cover behavior.)
+     *
+     */
     @Override
     public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side) {
-        return true;
+        IGregTechTileEntity gregTechTileEntity = getGregTile(world, pos);
+        return gregTechTileEntity != null && gregTechTileEntity.canOutputRedstone((byte) side.getOpposite().getIndex());
     }
 
     @Override
@@ -356,7 +362,7 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
     public int getWeakPower(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
         IGregTechTileEntity gregTechTileEntity = getGregTile(blockAccess, pos);
         if(gregTechTileEntity != null) {
-            gregTechTileEntity.getOutputRedstoneSignal((byte) side.getIndex());
+            return gregTechTileEntity.getOutputRedstoneSignal((byte) side.getOpposite().getIndex());
         }
         return 0;
     }
@@ -365,7 +371,7 @@ public class GT_Block_Machines extends GT_Generic_Block implements IDebugableBlo
     public int getStrongPower(IBlockState blockState, IBlockAccess blockAccess, BlockPos pos, EnumFacing side) {
         IGregTechTileEntity gregTechTileEntity = getGregTile(blockAccess, pos);
         if(gregTechTileEntity != null) {
-            gregTechTileEntity.getStrongOutputRedstoneSignal((byte) side.getIndex());
+            return gregTechTileEntity.getStrongOutputRedstoneSignal((byte) side.getOpposite().getIndex());
         }
         return 0;
     }


### PR DESCRIPTION
This fix is twofold. First, it fixes the calls to vanilla's `getRedstonePower` and impl's of vanilla's `getWeak/StrongPower` - the `side` parameter is reversed, and the `pos` of `getRedstonePower` should be the neighboring block. Neighbors are also notified of redstone changes. Second, it fixes the visual appearance of redstone wires connecting to machines, making it fit the vanilla rule "emitters connect, consumers don't". This fixes issues where a wire appears to connect to a Machine Controller, but does not actually control it.

Tested with Machine Controller and Energy Detector, should work for the rest too.