### PR TITLE
[1.10.2] Fix machine sounds

### DIFF
--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -23,6 +23,8 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fml.relauncher.Side;
@@ -219,8 +221,11 @@ public class GregTech_API {
     /**
      * Adds Biomes to the Biome Lists for World Generation
      */
+
+    private static int size = 0; /* Used to assign Minecraft IDs to our SoundEvents. We don't use them. */
     static {
         sItemStackMappings.add(sCoverItems);
+        size = SoundEvent.REGISTRY.getKeys().size();
 
         sDimensionalList.add(-1);
         sDimensionalList.add(0);
@@ -230,33 +235,42 @@ public class GregTech_API {
         sSoundList.put(1, "block.anvil.use");//SoundEvents.BLOCK_ANVIL_USE.getSoundName().toString());
         sSoundList.put(2, "block.anvil.break");//SoundEvents.BLOCK_ANVIL_BREAK.getSoundName().toString());
         sSoundList.put(3, "block.stone_button.click_on");//SoundEvents.BLOCK_STONE_BUTTON_CLICK_ON.getSoundName().toString());
-        sSoundList.put(4, "entity.item.break");//SoundEvents.ENTITY_ITEM_BREAK.getSoundName().toString());
+        sSoundList.put(4, "block.fire.extinguish");//SoundEvents.ENTITY_ITEM_BREAK.getSoundName().toString());
         sSoundList.put(5, "entity.generic.explode");//SoundEvents.ENTITY_GENERIC_EXPLODE.getSoundName().toString());
         sSoundList.put(6, "item.firecharge.use");//SoundEvents.ITEM_FIRECHARGE_USE.getSoundName().toString());
 
-        sSoundList.put(100, aTextIC2Lower + ":" + "tools.Wrench");
-        sSoundList.put(101, aTextIC2Lower + ":" + "tools.RubberTrampoline");
-        sSoundList.put(102, aTextIC2Lower + ":" + "tools.Painter");
-        sSoundList.put(103, aTextIC2Lower + ":" + "tools.BatteryUse");
-        sSoundList.put(104, aTextIC2Lower + ":" + "tools.chainsaw.ChainsawUseOne");
-        sSoundList.put(105, aTextIC2Lower + ":" + "tools.chainsaw.ChainsawUseTwo");
-        sSoundList.put(106, aTextIC2Lower + ":" + "tools.drill.DrillSoft");
-        sSoundList.put(107, aTextIC2Lower + ":" + "tools.drill.DrillHard");
-        sSoundList.put(108, aTextIC2Lower + ":" + "tools.ODScanner");
+        registerSound(100, aTextIC2Lower + ":" + "tools.Wrench");
+        registerSound(101, aTextIC2Lower + ":" + "tools.RubberTrampoline");
+        registerSound(102, aTextIC2Lower + ":" + "tools.Painter");
+        registerSound(103, aTextIC2Lower + ":" + "tools.BatteryUse");
+        registerSound(104, aTextIC2Lower + ":" + "tools.chainsaw.ChainsawUseOne");
+        registerSound(105, aTextIC2Lower + ":" + "tools.chainsaw.ChainsawUseTwo");
+        registerSound(106, aTextIC2Lower + ":" + "tools.drill.DrillSoft");
+        registerSound(107, aTextIC2Lower + ":" + "tools.drill.DrillHard");
+        registerSound(108, aTextIC2Lower + ":" + "tools.ODScanner");
 
-        sSoundList.put(200, aTextIC2Lower + ":" + "machines.ExtractorOp");
-        sSoundList.put(201, aTextIC2Lower + ":" + "machines.MaceratorOp");
-        sSoundList.put(202, aTextIC2Lower + ":" + "machines.InductionLoop");
-        sSoundList.put(203, aTextIC2Lower + ":" + "machines.CompressorOp");
-        sSoundList.put(204, aTextIC2Lower + ":" + "machines.RecyclerOp");
-        sSoundList.put(205, aTextIC2Lower + ":" + "machines.MinerOp");
-        sSoundList.put(206, aTextIC2Lower + ":" + "machines.PumpOp");
-        sSoundList.put(207, aTextIC2Lower + ":" + "machines.ElectroFurnaceLoop");
-        sSoundList.put(208, aTextIC2Lower + ":" + "machines.InductionLoop");
-        sSoundList.put(209, aTextIC2Lower + ":" + "machines.MachineOverload");
-        sSoundList.put(210, aTextIC2Lower + ":" + "machines.InterruptOne");
-        sSoundList.put(211, aTextIC2Lower + ":" + "machines.KaChing");
-        sSoundList.put(212, aTextIC2Lower + ":" + "machines.MagnetizerLoop");
+        registerSound(200, aTextIC2Lower + ":" + "machines.ExtractorOp");
+        registerSound(201, aTextIC2Lower + ":" + "machines.MaceratorOp");
+        registerSound(202, aTextIC2Lower + ":" + "machines.InductionLoop");
+        registerSound(203, aTextIC2Lower + ":" + "machines.CompressorOp");
+        registerSound(204, aTextIC2Lower + ":" + "machines.RecyclerOp");
+        registerSound(205, aTextIC2Lower + ":" + "machines.MinerOp");
+        registerSound(206, aTextIC2Lower + ":" + "machines.PumpOp");
+        registerSound(207, aTextIC2Lower + ":" + "machines.ElectroFurnaceLoop");
+        registerSound(208, aTextIC2Lower + ":" + "machines.InductionLoop");
+        registerSound(209, aTextIC2Lower + ":" + "machines.MachineOverload");
+        registerSound(210, aTextIC2Lower + ":" + "machines.InterruptOne");
+        registerSound(211, aTextIC2Lower + ":" + "machines.KaChing");
+        registerSound(212, aTextIC2Lower + ":" + "machines.MagnetizerLoop");
+    }
+
+    public static void registerSound(int id, String name) {
+        ResourceLocation loc = new ResourceLocation(name);
+        SoundEvent e = new SoundEvent(loc);
+        if(!SoundEvent.REGISTRY.containsKey(loc)) {
+            SoundEvent.REGISTRY.register(size++, loc, e);
+        }
+        sSoundList.put(id, name);
     }
 
     /**

--- a/src/main/java/gregtech/api/metatileentity/BaseTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseTileEntity.java
@@ -2,6 +2,7 @@ package gregtech.api.metatileentity;
 
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IHasWorldObjectAndCoords;
+import gregtech.api.net.GT_Packet_Block_Event;
 import gregtech.api.util.GT_Utility;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -472,7 +473,14 @@ public abstract class BaseTileEntity extends TileEntity implements IHasWorldObje
 
     @Override
     public final void sendBlockEvent(byte aID, byte aValue) {
-        //NW.sendPacketToAllPlayersInRange(worldObj, new GT_Packet_Block_Event(getXCoord(), (short) getYCoord(), getZCoord(), aID, aValue), getXCoord(), getZCoord());
+        NW.sendToAllAround(worldObj, new GT_Packet_Block_Event(getXCoord(),
+                                                               (short) getYCoord(),
+                                                               getZCoord(),
+                                                               aID,
+                                                               aValue),
+                           getXCoord(),
+                           getYCoord(),
+                           getZCoord());
     }
 
     private boolean crossedChunkBorder(int aX, int aZ) {

--- a/src/main/java/gregtech/api/net/GT_PacketHandler.java
+++ b/src/main/java/gregtech/api/net/GT_PacketHandler.java
@@ -14,6 +14,7 @@ public class GT_PacketHandler extends SimpleNetworkWrapper {
         super("gregtech_network");
         registerMessage(0, GT_Packet_TileEntity.class, Side.CLIENT);
         registerMessage(2, GT_Packet_Sound.class, Side.CLIENT);
+        registerMessage(3, GT_Packet_Block_Event.class, Side.CLIENT);
     }
 
     public void registerMessage(int discriminator, Class packet, Side handleSide) {

--- a/src/main/java/gregtech/api/net/GT_PacketHandler.java
+++ b/src/main/java/gregtech/api/net/GT_PacketHandler.java
@@ -1,6 +1,8 @@
 package gregtech.api.net;
 
 import gregtech.GT_Mod;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.IThreadListener;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
@@ -33,11 +35,19 @@ public class GT_PacketHandler extends SimpleNetworkWrapper {
 
         @Override
         public GT_Packet onMessage(GT_Packet message, MessageContext ctx) {
+            IThreadListener listener;
+            World world;
             if(ctx.side == Side.SERVER) {
-                message.process(ctx.getServerHandler().playerEntity.worldObj);
+                world = ctx.getServerHandler().playerEntity.worldObj;
+                listener = world.getMinecraftServer();
             } else {
-                message.process(GT_Mod.gregtechproxy.getThePlayer().worldObj);
+                world = GT_Mod.gregtechproxy.getThePlayer().worldObj;
+                listener = Minecraft.getMinecraft();
             }
+            listener.addScheduledTask(() -> {
+                message.process(world);
+            });
+
             return null;
         }
     }

--- a/src/main/java/gregtech/api/net/GT_Packet_Block_Event.java
+++ b/src/main/java/gregtech/api/net/GT_Packet_Block_Event.java
@@ -1,0 +1,55 @@
+package gregtech.api.net;
+
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+
+/**
+ * Used to transfer Block Events in a much better fashion
+ */
+public class GT_Packet_Block_Event extends GT_Packet {
+    private int mX, mZ;
+    private short mY;
+    private byte mID, mValue;
+
+    public GT_Packet_Block_Event() {}
+
+    public GT_Packet_Block_Event(int aX, short aY, int aZ, byte aID, byte aValue) {
+        mX = aX;
+        mY = aY;
+        mZ = aZ;
+        mID = aID;
+        mValue = aValue;
+    }
+
+    @Override
+    public void encode(ByteBuf buf) {
+        buf.writeInt(mX);
+        buf.writeShort(mY);
+        buf.writeInt(mZ);
+        buf.writeByte(mID);
+        buf.writeByte(mValue);
+    }
+
+    @Override
+    public void decode(ByteBuf buf) {
+        mX = buf.readInt();
+        mY = buf.readShort();
+        mZ = buf.readInt();
+        mID = buf.readByte();
+        mValue = buf.readByte();
+    }
+
+    @Override
+    public void process(World aWorld) {
+        if (aWorld != null) {
+            TileEntity tTileEntity = aWorld.getTileEntity(new BlockPos(mX, mY, mZ));
+            if (tTileEntity != null) tTileEntity.receiveClientEvent(mID, mValue);
+        }
+    }
+}

--- a/src/main/java/gregtech/api/threads/GT_Runnable_Sound.java
+++ b/src/main/java/gregtech/api/threads/GT_Runnable_Sound.java
@@ -33,8 +33,7 @@ public class GT_Runnable_Sound implements Runnable {
     public void run() {
         SoundEvent soundEvent = SoundEvent.REGISTRY.getObject(mSoundLocation);
         if(soundEvent != null) {
-            PositionedSound sound = new PositionedSound(soundEvent, SoundCategory.BLOCKS) {};
-            Minecraft.getMinecraft().getSoundHandler().playSound(sound);
+            mWorld.playSound((double)mX, (double)mY, (double)mZ, soundEvent, SoundCategory.BLOCKS, 1.0f, 1.0f, false);
         }
     }
 


### PR DESCRIPTION
Restores machine processing and steam exhaust sounds. Registers all needed sounds with Minecraft's sound event registry. Plays the sounds via `World.playSound()`. Revives the GT_Packet_Block_Event, rewriting it to match the new packet class. 

Notably, packet processing is now scheduled on the main client or server thread instead of the network I/O thread, potentially fixing various concurrency errors.