### PR TITLE
[1.10.2] Fix #873

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,7 @@ forge.version=12.18.1.2079
 gt.version=5.10.34
 
 forestry.version=5.2.7.220
-ic2.version=2.6.99-ex110
+ic2.version=2.6.151-ex110
 jei.version=3.7.10.237
 codechickenlib.version=2.4.3.162
 

--- a/src/main/java/gregtech/api/util/GT_BaseCrop.java
+++ b/src/main/java/gregtech/api/util/GT_BaseCrop.java
@@ -13,6 +13,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.Loader;
 
 import java.util.ArrayList;
@@ -160,6 +161,15 @@ public class GT_BaseCrop extends CropCard {
     @Override
     public boolean onRightClick(ICropTile cropTile, EntityPlayer player) {
         return canBeHarvested(cropTile) && super.onRightClick(cropTile, player);
+    }
+    
+    @Override
+    public List<ResourceLocation> getTexturesLocation() {
+        List<ResourceLocation> list = new ArrayList<ResourceLocation>();
+        for (int size = 1; size <= getMaxSize(); size++) {
+            list.add(new ResourceLocation("ic2", "blocks/crop/blockCrop." + getId() + "." + size));
+        }
+        return list;
     }
 
 

--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -11,11 +11,11 @@ import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.objects.ItemData;
 import ic2.api.item.ElectricItem;
 import ic2.api.item.IBoxable;
+import ic2.api.item.IC2Items;
 import ic2.api.item.IElectricItem;
 import ic2.api.item.ISpecialElectricItem;
 import ic2.api.reactor.IReactorComponent;
 import ic2.api.recipe.*;
-import ic2.core.Ic2Items;
 import ic2.core.block.state.IIdProvider;
 import ic2.core.ref.BlockName;
 import ic2.core.ref.FluidName;
@@ -1723,7 +1723,7 @@ public class GT_ModHandler {
 
     public static int getCapsuleCellContainerCount(ItemStack aStack) {
         if (aStack == null) return 0;
-        return GT_Utility.areStacksEqual(GT_Utility.getContainerForFilledItem(aStack, true), ItemList.Cell_Empty.get(1)) || OrePrefixes.cell.contains(aStack) || OrePrefixes.cellPlasma.contains(aStack) || GT_Utility.areStacksEqual(aStack, Ic2Items.waterCell) ? 1 : 0;
+        return GT_Utility.areStacksEqual(GT_Utility.getContainerForFilledItem(aStack, true), ItemList.Cell_Empty.get(1)) || OrePrefixes.cell.contains(aStack) || OrePrefixes.cellPlasma.contains(aStack) || GT_Utility.areStacksEqual(aStack, IC2Items.getItem("fluid_cell", "water")) ? 1 : 0;
     }
 
     public static class RecipeBits {

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -1705,14 +1705,14 @@ public class GT_Utility {
                                 + "  Gain: " + cropTile.getCrop().getGain(cropTile)
                                 + "  Resistance: " + properties.getDefensive()
                         );
-                        tList.add("Plant -- Fertilizer: " + cropTile.getNutrients()
-                                + "  Water: " + cropTile.getHumidity()
+                        tList.add("Plant -- Fertilizer: " + cropTile.getTerrainNutrients()
+                                + "  Water: " + cropTile.getTerrainHumidity()
                                 + "  Weed-Ex: " + cropTile.getStorageWeedEX()
                                 + "  Scan-Level: " + cropTile.getScanLevel()
                         );
-                        tList.add("Environment -- Nutrients: " + cropTile.getNutrients()
-                                + "  Humidity: " + cropTile.getHumidity()
-                                + "  Air-Quality: " + cropTile.getAirQuality()
+                        tList.add("Environment -- Nutrients: " + cropTile.getTerrainNutrients()
+                                + "  Humidity: " + cropTile.getTerrainHumidity()
+                                + "  Air-Quality: " + cropTile.getTerrainAirQuality()
                         );
                         tList.add("Discovered by: " + cropTile.getCrop().getDiscoveredBy());
                     }


### PR DESCRIPTION
Summary:
* Add missing `getTexturesLocation()` in GT_BaseCrop;
* Replace `Ic2Items.waterCell` with ` IC2Items.getItem("fluid_cell", "water")` since there is only universal fluid cell;
* `getNutrients()` -> `getTerrainNutrients()`, same for `getHumidity()` and `getAirQuality()`. 

Please let me know if I forget something.