### PR TITLE
New modes for Fluid Filter

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
@@ -18,52 +18,51 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
-import java.util.logging.Logger;
-import gregtech.api.util.GT_Log;
+
 
 public class GT_Cover_Fluidfilter
         extends GT_CoverBehavior {
-			
+            
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         return aCoverVariable;
     }
 
-	public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+    public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         int aFilterMode = aCoverVariable & 7;
-		aCoverVariable ^=aFilterMode;
-		aFilterMode = (aFilterMode + (aPlayer.isSneaking()? -1 : 1)) % 4;
+        aCoverVariable ^=aFilterMode;
+        aFilterMode = (aFilterMode + (aPlayer.isSneaking()? -1 : 1)) % 4;
         if(aFilterMode < 0){aFilterMode = 3;}
         switch(aFilterMode) {
             case 0: GT_Utility.sendChatToPlayer(aPlayer, "Allow input, no output"); break;
             case 1: GT_Utility.sendChatToPlayer(aPlayer, "Deny input, no output"); break;
-			case 2: GT_Utility.sendChatToPlayer(aPlayer, "Allow input, permit any output"); break;
+            case 2: GT_Utility.sendChatToPlayer(aPlayer, "Allow input, permit any output"); break;
             case 3: GT_Utility.sendChatToPlayer(aPlayer, "Deny input, permit any output"); break;
         }
-		aCoverVariable|=aFilterMode;
+        aCoverVariable|=aFilterMode;
         return aCoverVariable;
     }
-	
+    
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
        //System.out.println("rightclick");
-    	if (((aX > 0.375D) && (aX < 0.625D)) || ((aSide > 3) && (((aY > 0.375D) && (aY < 0.625D)) || ((aSide < 2) && (((aZ > 0.375D) && (aZ < 0.625D)) || (aSide == 2) || (aSide == 3)))))) {
+        if (((aX > 0.375D) && (aX < 0.625D)) || ((aSide > 3) && (((aY > 0.375D) && (aY < 0.625D)) || ((aSide < 2) && (((aZ > 0.375D) && (aZ < 0.625D)) || (aSide == 2) || (aSide == 3)))))) {
             ItemStack tStack = aPlayer.inventory.getCurrentItem();
             if(tStack!=null){
             FluidStack tFluid = FluidContainerRegistry.getFluidForFilledItem(tStack);
             if(tFluid!=null){
-            	//System.out.println(tFluid.getLocalizedName()+" "+tFluid.getFluidID());
-				int aFluid = tFluid.getFluidID();
-            	aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
+                //System.out.println(tFluid.getLocalizedName()+" "+tFluid.getFluidID());
+                int aFluid = tFluid.getFluidID();
+                aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
                 aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-				FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid),1000);
+                FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid),1000);
                 GT_Utility.sendChatToPlayer(aPlayer, "Filter Fluid: " + sFluid.getLocalizedName());
             }else if(tStack.getItem() instanceof IFluidContainerItem){
-            	IFluidContainerItem tContainer = (IFluidContainerItem)tStack.getItem();
+                IFluidContainerItem tContainer = (IFluidContainerItem)tStack.getItem();
                 if(tContainer.getFluid(tStack) != null) {
-					int aFluid = tContainer.getFluid(tStack).getFluidID();
-					aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
-					aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-					FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid),1000);
-					GT_Utility.sendChatToPlayer(aPlayer, "Filter Fluid: " + sFluid.getLocalizedName());
+                    int aFluid = tContainer.getFluid(tStack).getFluidID();
+                    aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
+                    aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
+                    FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid),1000);
+                    GT_Utility.sendChatToPlayer(aPlayer, "Filter Fluid: " + sFluid.getLocalizedName());
                 }
             }
             }
@@ -74,16 +73,16 @@ public class GT_Cover_Fluidfilter
     
     @Override
     public boolean letsFluidIn(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
-    	if(aFluid==null){return true;}
-		int aFilterMode = aCoverVariable & 7;
-		int aFilterFluid = aCoverVariable >>> 3;
-		return aFluid.getID() == aFilterFluid ? (aFilterMode == 0 || aFilterMode == 2 ? true : false) : (aFilterMode == 1 || aFilterMode == 3 ? true : false);
+        if(aFluid==null){return true;}
+        int aFilterMode = aCoverVariable & 7;
+        int aFilterFluid = aCoverVariable >>> 3;
+        return aFluid.getID() == aFilterFluid ? (aFilterMode == 0 || aFilterMode == 2 ? true : false) : (aFilterMode == 1 || aFilterMode == 3 ? true : false);
     }
     
     @Override
     public boolean letsFluidOut(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
-		int aFilterMode = aCoverVariable & 7;
-		return  aFilterMode == 0 || aFilterMode == 1 ? false : true;
+        int aFilterMode = aCoverVariable & 7;
+        return  aFilterMode == 0 || aFilterMode == 1 ? false : true;
     }
     
     public boolean alwaysLookConnected(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
@@ -18,13 +18,31 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
+import java.util.logging.Logger;
+import gregtech.api.util.GT_Log;
 
 public class GT_Cover_Fluidfilter
         extends GT_CoverBehavior {
+			
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         return aCoverVariable;
     }
 
+	public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        int aFilterMode = aCoverVariable & 7;
+		aCoverVariable ^=aFilterMode;
+		aFilterMode = (aFilterMode + (aPlayer.isSneaking()? -1 : 1)) % 4;
+        if(aFilterMode < 0){aFilterMode = 3;}
+        switch(aFilterMode) {
+            case 0: GT_Utility.sendChatToPlayer(aPlayer, "Allow input, no output"); break;
+            case 1: GT_Utility.sendChatToPlayer(aPlayer, "Deny input, no output"); break;
+			case 2: GT_Utility.sendChatToPlayer(aPlayer, "Allow input, permit any output"); break;
+            case 3: GT_Utility.sendChatToPlayer(aPlayer, "Deny input, permit any output"); break;
+        }
+		aCoverVariable|=aFilterMode;
+        return aCoverVariable;
+    }
+	
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
        //System.out.println("rightclick");
     	if (((aX > 0.375D) && (aX < 0.625D)) || ((aSide > 3) && (((aY > 0.375D) && (aY < 0.625D)) || ((aSide < 2) && (((aZ > 0.375D) && (aZ < 0.625D)) || (aSide == 2) || (aSide == 3)))))) {
@@ -33,18 +51,19 @@ public class GT_Cover_Fluidfilter
             FluidStack tFluid = FluidContainerRegistry.getFluidForFilledItem(tStack);
             if(tFluid!=null){
             	//System.out.println(tFluid.getLocalizedName()+" "+tFluid.getFluidID());
-            	aCoverVariable = tFluid.getFluidID();
+				int aFluid = tFluid.getFluidID();
+            	aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
                 aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-        	FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aCoverVariable),1000);
+				FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid),1000);
                 GT_Utility.sendChatToPlayer(aPlayer, "Filter Fluid: " + sFluid.getLocalizedName());
             }else if(tStack.getItem() instanceof IFluidContainerItem){
             	IFluidContainerItem tContainer = (IFluidContainerItem)tStack.getItem();
                 if(tContainer.getFluid(tStack) != null) {
-                    aCoverVariable = tContainer.getFluid(tStack).getFluidID();
-                    aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
-                    //System.out.println("fluidcontainer " + aCoverVariable);
-                    FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aCoverVariable), 1000);
-                    GT_Utility.sendChatToPlayer(aPlayer, "Filter Fluid: " + sFluid.getLocalizedName());
+					int aFluid = tContainer.getFluid(tStack).getFluidID();
+					aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
+					aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
+					FluidStack sFluid = new FluidStack(FluidRegistry.getFluid(aFluid),1000);
+					GT_Utility.sendChatToPlayer(aPlayer, "Filter Fluid: " + sFluid.getLocalizedName());
                 }
             }
             }
@@ -56,13 +75,15 @@ public class GT_Cover_Fluidfilter
     @Override
     public boolean letsFluidIn(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
     	if(aFluid==null){return true;}
-    	return aFluid.getID() == aCoverVariable;
+		int aFilterMode = aCoverVariable & 7;
+		int aFilterFluid = aCoverVariable >>> 3;
+		return aFluid.getID() == aFilterFluid ? (aFilterMode == 0 || aFilterMode == 2 ? true : false) : (aFilterMode == 1 || aFilterMode == 3 ? true : false);
     }
     
     @Override
     public boolean letsFluidOut(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
-    	if(aFluid==null) return false;
-    	return aFluid.getID() == aCoverVariable;
+		int aFilterMode = aCoverVariable & 7;
+		return  aFilterMode == 0 || aFilterMode == 1 ? false : true;
     }
     
     public boolean alwaysLookConnected(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {


### PR DESCRIPTION
Introduce new modes for Fluid Filter: allow input for the filtered fluid (as it was before) and allow anything but the filtered fluid (deny i.e. inverted allow). 
![image](https://cloud.githubusercontent.com/assets/16781357/22861461/66547008-f12a-11e6-8c76-241dc5970fc5.png)

**The Filter can only work in the input mode** (it have always worked that way and that was very confusing). Fixing this will take some changes in the API. I tried to make it work and failed. So i just added an abillity to allow/deny fluid flow to output similar to shutter covers. Might be useful if you want to push processed fluid from a machine in the same pipe.

With the new modes it's now possible to build a proper fluid sorting and processing system for the most basic needs.

If you have a suspicion that this code might fail then please warn me.