### PR TITLE
Kill excess redraws

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -350,6 +350,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public boolean receiveClientEvent(int aEventID, int aValue) {
+        boolean tNeedsRedraw = false;
         super.receiveClientEvent(aEventID, aValue);
 
         if (hasValidMetaTileEntity()) {
@@ -362,10 +363,13 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         }
 
         if (isClientSide()) {
-            issueTextureUpdate();
+
             switch (aEventID) {
                 case 0:
-                    mConnections = (byte) aValue;
+                    if (mConnections != (byte) aValue) {
+                        mConnections = (byte) aValue;
+                        tNeedsRedraw = true;
+                    }
                     break;
                 case 1:
                     if (hasValidMetaTileEntity()) mMetaTileEntity.onValueUpdate((byte) aValue);
@@ -395,6 +399,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                         mMetaTileEntity.stopSoundLoop((byte) aValue, getXCoord() + 0.5, getYCoord() + 0.5, getZCoord() + 0.5);
                     break;
             }
+            if (tNeedsRedraw) issueTextureUpdate();
         }
         return true;
     }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -327,18 +327,38 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     public final void receiveMetaTileEntityData(short aID, int aCover0, int aCover1, int aCover2, int aCover3, int aCover4, int aCover5, byte aTextureData, byte aUpdateData, byte aRedstoneData, byte aColorData) {
-        issueTextureUpdate();
+        boolean tNeedsRedraw = false;
         if (aID > 0 && mID != aID) {
             mID = aID;
             createNewMetatileEntity(mID);
+            tNeedsRedraw = true;
         }
 
-        mCoverSides[0] = aCover0;
-        mCoverSides[1] = aCover1;
-        mCoverSides[2] = aCover2;
-        mCoverSides[3] = aCover3;
-        mCoverSides[4] = aCover4;
-        mCoverSides[5] = aCover5;
+
+        if (mCoverSides[0] != aCover0) {
+            mCoverSides[0] = aCover0;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[1] != aCover1) {
+            mCoverSides[1] = aCover1;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[2] != aCover2) {
+            mCoverSides[2] = aCover2;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[3] != aCover3) {
+            mCoverSides[3] = aCover3;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[4] != aCover4) {
+            mCoverSides[4] = aCover4;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[5] != aCover5) {
+            mCoverSides[5] = aCover5;
+            tNeedsRedraw = true;
+        }
 
         for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
 
@@ -346,6 +366,8 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         receiveClientEvent(1, aUpdateData);
         receiveClientEvent(2, aColorData);
         receiveClientEvent(3, aRedstoneData);
+
+        if (tNeedsRedraw) issueTextureUpdate();
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -594,19 +594,38 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     public final void receiveMetaTileEntityData(short aID, int aCover0, int aCover1, int aCover2, int aCover3, int aCover4, int aCover5, byte aTextureData, byte aUpdateData, byte aRedstoneData, byte aColorData) {
-        issueTextureUpdate();
+        boolean tNeedsRedraw = false;
         if (mID != aID && aID > 0) {
             mID = aID;
             createNewMetatileEntity(mID);
+            tNeedsRedraw = true;
         }
 
 
-        mCoverSides[0] = aCover0;
-        mCoverSides[1] = aCover1;
-        mCoverSides[2] = aCover2;
-        mCoverSides[3] = aCover3;
-        mCoverSides[4] = aCover4;
-        mCoverSides[5] = aCover5;
+        if (mCoverSides[0] != aCover0) {
+            mCoverSides[0] = aCover0;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[1] != aCover1) {
+            mCoverSides[1] = aCover1;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[2] != aCover2) {
+            mCoverSides[2] = aCover2;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[3] != aCover3) {
+            mCoverSides[3] = aCover3;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[4] != aCover4) {
+            mCoverSides[4] = aCover4;
+            tNeedsRedraw = true;
+        }
+        if (mCoverSides[5] != aCover5) {
+            mCoverSides[5] = aCover5;
+            tNeedsRedraw = true;
+        }
 
         for (byte i = 0; i < 6; i++) mCoverBehaviors[i] = GregTech_API.getCoverBehavior(mCoverSides[i]);
 
@@ -614,6 +633,9 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         receiveClientEvent(1, aUpdateData);
         receiveClientEvent(2, aColorData);
         receiveClientEvent(3, aRedstoneData);
+
+        if (tNeedsRedraw) issueTextureUpdate();
+
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -618,6 +618,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public boolean receiveClientEvent(int aEventID, int aValue) {
+        boolean tNeedsRedraw = false;
         super.receiveClientEvent(aEventID, aValue);
 
         if (hasValidMetaTileEntity()) {
@@ -630,13 +631,25 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         }
 
         if (isClientSide()) {
-            issueTextureUpdate();
+
             switch (aEventID) {
                 case 0:
-                    mFacing = (byte) (aValue & 7);
-                    mActive = ((aValue & 8) != 0);
-                    mRedstone = ((aValue & 16) != 0);
-     				mLockUpgrade = ((aValue&32) != 0);
+                    if (mFacing != (byte) (aValue & 0x07)) {
+                        mFacing = (byte) (aValue & 0x07);
+                        tNeedsRedraw = true;
+                    }
+                    if (mActive != ((aValue & 0x08) != 0)) {
+                        mActive = ((aValue & 0x08) != 0);
+                        tNeedsRedraw = true;
+                    }
+                    if (mRedstone != ((aValue & 0x10) != 0)) {
+                        mRedstone = ((aValue & 0x10) != 0);
+                        tNeedsRedraw = true;
+                    }
+                    if (mLockUpgrade != ((aValue & 0x20) != 0)) {
+                        mLockUpgrade = ((aValue & 0x20) != 0);
+                        tNeedsRedraw = true;
+                    }
                     break;
                 case 1:
                     if (hasValidMetaTileEntity()) mMetaTileEntity.onValueUpdate((byte) aValue);
@@ -669,6 +682,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                     mLightValue = (byte) aValue;
                     break;
             }
+            if (tNeedsRedraw) issueTextureUpdate();
         }
         return true;
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -598,7 +598,10 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
 
     @Override
     public void onValueUpdate(byte aValue) {
-        mMainFacing = aValue;
+        if (mMainFacing != aValue) {
+            mMainFacing = aValue;
+            this.getBaseMetaTileEntity().issueTextureUpdate();
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch.java
@@ -49,7 +49,10 @@ public abstract class GT_MetaTileEntity_Hatch extends GT_MetaTileEntity_BasicTan
 
     @Override
     public final void onValueUpdate(byte aValue) {
-        mMachineBlock = (byte) (aValue & 127);
+        if (mMachineBlock != (byte) (aValue & 127)) {
+            mMachineBlock = (byte) (aValue & 127);
+            this.getBaseMetaTileEntity().issueTextureUpdate();
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_Locker.java
+++ b/src/main/java/gregtech/common/tileentities/storage/GT_MetaTileEntity_Locker.java
@@ -114,7 +114,10 @@ public class GT_MetaTileEntity_Locker
     }
 
     public void onValueUpdate(byte aValue) {
-        this.mType = aValue;
+        if (this.mType != aValue) {
+            this.mType = aValue;
+            this.getBaseMetaTileEntity().issueTextureUpdate();
+        }
     }
 
     public byte getUpdateData() {


### PR DESCRIPTION
Eliminates pointless redraws when server state is synced to the client, by checking whether the state was actually changed before issuing the redraw.