### PR TITLE
NEI Large Boiler Fuel Tab

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -1112,10 +1112,10 @@ public class GT_Mod implements IGT_Mod {
     private void addSolidFakeLargeBoilerFuels(){
         GT_Recipe.GT_Recipe_Map.sLargeBoilerFakeFuels.addSolidRecipes(
         		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Charcoal, 1),
-        		GT_OreDictUnificator.get(OrePrefixes.item, Materials.Charcoal, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.gem, Materials.Charcoal, 1),
         		GT_OreDictUnificator.get(OrePrefixes.block, Materials.Charcoal, 1),
         		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coal, 1),
-        		GT_OreDictUnificator.get(OrePrefixes.item, Materials.Coal, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.gem, Materials.Coal, 1),
         		GT_OreDictUnificator.get(OrePrefixes.block, Materials.Coal, 1),
         		GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Coal, 1),
         		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lignite, 1),
@@ -1125,12 +1125,19 @@ public class GT_Mod implements IGT_Mod {
         		GT_OreDictUnificator.get(OrePrefixes.log, Materials.Wood, 1),
         		GT_OreDictUnificator.get(OrePrefixes.plank, Materials.Wood, 1),
         		GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.slab, Materials.Wood, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Wood, 1),
         		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 1),
         		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 1),
         		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Caesium, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sulfur, 1),
         		GT_OreDictUnificator.get(ItemList.Block_SSFUEL.get(1, new Object[0])),
         		GT_OreDictUnificator.get(ItemList.Block_MSSFUEL.get(1, new Object[0])),
-        		new ItemStack(Items.lava_bucket),
-        		new ItemStack(Items.blaze_rod));
+        		GT_OreDictUnificator.get(OrePrefixes.bucket, Materials.Lava, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.rod, Materials.Blaze, 1));
+        if (Loader.isModLoaded("Thaumcraft")) {
+        	GT_Recipe.GT_Recipe_Map.sLargeBoilerFakeFuels.addSolidRecipe(GT_ModHandler.getModItem("Thaumcraft", "ItemResource", 1));
+        }
     }
+    
 }

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -811,6 +811,9 @@ public class GT_Mod implements IGT_Mod {
                 GregTech_API.mInputRF = false;
             }
         }
+        
+        addSolidFakeLargeBoilerFuels();
+        
         achievements = new GT_Achievements();
         GT_Log.out.println("GT_Mod: Loading finished, deallocating temporary Init Variables.");
         GregTech_API.sBeforeGTPreload = null;
@@ -1104,5 +1107,30 @@ public class GT_Mod implements IGT_Mod {
 
     public void doSonictronSound(ItemStack aStack, World aWorld, double aX, double aY, double aZ) {
         gregtechproxy.doSonictronSound(aStack, aWorld, aX, aY, aZ);
+    }
+    
+    private void addSolidFakeLargeBoilerFuels(){
+        GT_Recipe.GT_Recipe_Map.sLargeBoilerFakeFuels.addSolidRecipes(
+        		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Charcoal, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.item, Materials.Charcoal, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.block, Materials.Charcoal, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coal, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.item, Materials.Coal, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.block, Materials.Coal, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Coal, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lignite, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.gem, Materials.Lignite, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.block, Materials.Lignite, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.crushed, Materials.Lignite, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.log, Materials.Wood, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.plank, Materials.Wood, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 1),
+        		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Caesium, 1),
+        		GT_OreDictUnificator.get(ItemList.Block_SSFUEL.get(1, new Object[0])),
+        		GT_OreDictUnificator.get(ItemList.Block_MSSFUEL.get(1, new Object[0])),
+        		new ItemStack(Items.lava_bucket),
+        		new ItemStack(Items.blaze_rod));
     }
 }

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -1381,6 +1381,9 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     	
     	public GT_Recipe_Map_Large_Boiler_Fake_Fuels(){
     		super(new HashSet<GT_Recipe>(30), "gt.recipe.largeboilerfakefuels", "Large Boiler", null, RES_PATH_GUI + "basicmachines/Default", 1, 0, 1, 0, 1, E, 1, E, true , true);
+    		GT_Recipe explanatoryRecipe = new GT_Recipe(true, new ItemStack[]{}, new ItemStack[]{}, null, null, null, null, 1, 1, 1);
+    		explanatoryRecipe.setNeiDesc("Not all solid fuels are listed.", "Any item that burns in a", "vanilla furnace will burn in", "a Large Boiler.");
+    		addRecipe(explanatoryRecipe);
     	}
     	
     	public GT_Recipe addDenseLiquidRecipe(GT_Recipe recipe) {
@@ -1390,11 +1393,16 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     	public GT_Recipe addDieselRecipe(GT_Recipe recipe) {
     		return addRecipe(recipe,((double)recipe.mSpecialValue) / 40);
     	}
-    	
-    	public GT_Recipe addSolidRecipe(GT_Recipe recipe) {
-    		return addRecipe(recipe, ((double)recipe.mSpecialValue) / 80);
+
+    	public void addSolidRecipes(ItemStack ... itemStacks) {
+    		for(ItemStack itemStack : itemStacks){
+    			addSolidRecipe(itemStack);
+    		}
     	}
-    	
+    	    	
+    	public GT_Recipe addSolidRecipe(ItemStack fuelItemStack){
+    		return addRecipe(new GT_Recipe(true, new ItemStack[]{fuelItemStack}, new ItemStack[]{}, null, null, null, null, 1, 0, GT_ModHandler.getFuelValue(fuelItemStack) / 1600), ((double)GT_ModHandler.getFuelValue(fuelItemStack)) / 1600);
+    	}
     	
     	private GT_Recipe addRecipe(GT_Recipe recipe, double baseBurnTime){
 			recipe = new GT_Recipe(recipe);
@@ -1410,7 +1418,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
     		double tungstensteelBurnTime = baseBurnTime * 1.2 + floatErrorCorrection;
     		tungstensteelBurnTime -= tungstensteelBurnTime % 0.05;
     		
-    		recipe.setNeiDesc("Burn times in seconds:", 
+    		recipe.setNeiDesc("Burn time in seconds:", 
     				String.format("Bronze Boiler: %.2f", bronzeBurnTime), 
     				String.format("Steel Boiler: %.2f", steelBurnTime), 
     				String.format("Titanium Boiler: %.2f", titaniumBurnTime), 

--- a/src/main/java/gregtech/api/util/GT_Recipe.java
+++ b/src/main/java/gregtech/api/util/GT_Recipe.java
@@ -72,6 +72,11 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
      * If this Recipe needs the Output Slots to be completely empty. Needed in case you have randomised Outputs
      */
     public boolean mNeedsEmptyOutput = false;
+    /**
+     * Used for describing recipes that do not fit the default recipe pattern (for example Large Boiler Fuels)
+     */
+    private String[] neiDesc = null;
+    
     private GT_Recipe(GT_Recipe aRecipe) {
         mInputs = GT_Utility.copyStackArray((Object[]) aRecipe.mInputs);
         mOutputs = GT_Utility.copyStackArray((Object[]) aRecipe.mOutputs);
@@ -173,6 +178,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                 // Diesel Generator
                 case 0:
                     GT_Recipe_Map.sDieselFuels.addRecipe(this);
+                    GT_Recipe_Map.sLargeBoilerFakeFuels.addDieselRecipe(this);
                     break;
                 // Gas Turbine
                 case 1:
@@ -193,6 +199,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
                 // Fluid Generator. Usually 3. Every wrong Type ends up in the Semifluid Generator
                 default:
                     GT_Recipe_Map.sDenseLiquidFuels.addRecipe(this);
+                    GT_Recipe_Map.sLargeBoilerFakeFuels.addDenseLiquidRecipe(this);
                     break;
             }
         }
@@ -433,7 +440,14 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         return 0;
     }
 
-    public static class GT_Recipe_AssemblyLine{
+    public String[] getNeiDesc() {
+		return neiDesc;
+	}
+	protected void setNeiDesc(String... neiDesc) {
+		this.neiDesc = neiDesc;
+	}
+
+	public static class GT_Recipe_AssemblyLine{
         public static final ArrayList<GT_Recipe_AssemblyLine> sAssemblylineRecipes = new ArrayList<GT_Recipe_AssemblyLine>();
         
         public ItemStack mResearchItem;
@@ -512,7 +526,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public static final GT_Recipe_Map sAlloySmelterRecipes = new GT_Recipe_Map(new HashSet<GT_Recipe>(3000), "gt.recipe.alloysmelter", "Alloy Smelter", null, RES_PATH_GUI + "basicmachines/AlloySmelter", 2, 1, 2, 0, 1, E, 1, E, true, true);
         public static final GT_Recipe_Map sAssemblerRecipes = new GT_Recipe_Map_Assembler(new HashSet<GT_Recipe>(300), "gt.recipe.assembler", "Assembler", null, RES_PATH_GUI + "basicmachines/Assembler", 2, 1, 1, 0, 1, E, 1, E, true, true);
         public static final GT_Recipe_Map sCircuitAssemblerRecipes = new GT_Recipe_Map_Assembler(new HashSet<GT_Recipe>(300), "gt.recipe.circuitassembler", "Circuit Assembler", null, RES_PATH_GUI + "basicmachines/CircuitAssembler", 6, 1, 1, 0, 1, E, 1, E, true, true);
-         public static final GT_Recipe_Map sCannerRecipes = new GT_Recipe_Map(new HashSet<GT_Recipe>(300), "gt.recipe.canner", "Canning Machine", null, RES_PATH_GUI + "basicmachines/Canner", 2, 2, 1, 0, 1, E, 1, E, true, true);
+        public static final GT_Recipe_Map sCannerRecipes = new GT_Recipe_Map(new HashSet<GT_Recipe>(300), "gt.recipe.canner", "Canning Machine", null, RES_PATH_GUI + "basicmachines/Canner", 2, 2, 1, 0, 1, E, 1, E, true, true);
         public static final GT_Recipe_Map sCNCRecipes = new GT_Recipe_Map(new HashSet<GT_Recipe>(100), "gt.recipe.cncmachine", "CNC Machine", null, RES_PATH_GUI + "basicmachines/Default", 2, 1, 2, 1, 1, E, 1, E, true, true);
         public static final GT_Recipe_Map sLatheRecipes = new GT_Recipe_Map(new HashSet<GT_Recipe>(400), "gt.recipe.lathe", "Lathe", null, RES_PATH_GUI + "basicmachines/Lathe", 1, 2, 1, 0, 1, E, 1, E, true, true);
         public static final GT_Recipe_Map sCutterRecipes = new GT_Recipe_Map(new HashSet<GT_Recipe>(200), "gt.recipe.cuttingsaw", "Cutting Saw", null, RES_PATH_GUI + "basicmachines/Cutter", 1, 2, 1, 1, 1, E, 1, E, true, true);
@@ -530,6 +544,7 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public static final GT_Recipe_Map_Fuel sSmallNaquadahReactorFuels = new GT_Recipe_Map_Fuel(new HashSet<GT_Recipe>(10), "gt.recipe.smallnaquadahreactor", "Small Naquadah Reactor", null, RES_PATH_GUI + "basicmachines/Default", 1, 1, 0, 0, 1, "Fuel Value: ", 1000, " EU", true, true);
         public static final GT_Recipe_Map_Fuel sLargeNaquadahReactorFuels = new GT_Recipe_Map_Fuel(new HashSet<GT_Recipe>(10), "gt.recipe.largenaquadahreactor", "Large Naquadah Reactor", null, RES_PATH_GUI + "basicmachines/Default", 1, 1, 0, 0, 1, "Fuel Value: ", 1000, " EU", true, true);
         public static final GT_Recipe_Map_Fuel sFluidNaquadahReactorFuels = new GT_Recipe_Map_Fuel(new HashSet<GT_Recipe>(10), "gt.recipe.fluidnaquadahreactor", "Fluid Naquadah Reactor", null, RES_PATH_GUI + "basicmachines/Default", 1, 1, 0, 0, 1, "Fuel Value: ", 1000, " EU", true, true);
+        public static final GT_Recipe_Map_Large_Boiler_Fake_Fuels sLargeBoilerFakeFuels = new GT_Recipe_Map_Large_Boiler_Fake_Fuels();
         
         /**
          * HashMap of Recipes based on their Items
@@ -1360,5 +1375,48 @@ public class GT_Recipe implements Comparable<GT_Recipe> {
         public boolean containsInput(Fluid aFluid) {
             return super.containsInput(aFluid) || Dyes.isAnyFluidDye(aFluid);
         }
+    }
+
+    public static class GT_Recipe_Map_Large_Boiler_Fake_Fuels extends GT_Recipe_Map {
+    	
+    	public GT_Recipe_Map_Large_Boiler_Fake_Fuels(){
+    		super(new HashSet<GT_Recipe>(30), "gt.recipe.largeboilerfakefuels", "Large Boiler", null, RES_PATH_GUI + "basicmachines/Default", 1, 0, 1, 0, 1, E, 1, E, true , true);
+    	}
+    	
+    	public GT_Recipe addDenseLiquidRecipe(GT_Recipe recipe) {
+    		return addRecipe(recipe, ((double)recipe.mSpecialValue) / 10);
+    	}
+
+    	public GT_Recipe addDieselRecipe(GT_Recipe recipe) {
+    		return addRecipe(recipe,((double)recipe.mSpecialValue) / 40);
+    	}
+    	
+    	public GT_Recipe addSolidRecipe(GT_Recipe recipe) {
+    		return addRecipe(recipe, ((double)recipe.mSpecialValue) / 80);
+    	}
+    	
+    	
+    	private GT_Recipe addRecipe(GT_Recipe recipe, double baseBurnTime){
+			recipe = new GT_Recipe(recipe);
+			//Some recipes will have a burn time like 15.9999999 and % always rounds down
+			double floatErrorCorrection = 0.0001;
+			
+    		double bronzeBurnTime = baseBurnTime * 2 + floatErrorCorrection;
+    		bronzeBurnTime -= bronzeBurnTime % 0.05;
+    		double steelBurnTime = baseBurnTime * 1.5 + floatErrorCorrection;
+    		steelBurnTime -= steelBurnTime % 0.05;
+    		double titaniumBurnTime = baseBurnTime * 1.3 + floatErrorCorrection;
+    		titaniumBurnTime -= titaniumBurnTime % 0.05;
+    		double tungstensteelBurnTime = baseBurnTime * 1.2 + floatErrorCorrection;
+    		tungstensteelBurnTime -= tungstensteelBurnTime % 0.05;
+    		
+    		recipe.setNeiDesc("Burn times in seconds:", 
+    				String.format("Bronze Boiler: %.2f", bronzeBurnTime), 
+    				String.format("Steel Boiler: %.2f", steelBurnTime), 
+    				String.format("Titanium Boiler: %.2f", titaniumBurnTime), 
+    				String.format("Tungstensteel Boiler: %.2f", tungstensteelBurnTime));
+    		return super.addRecipe(recipe);
+    	}
+    	
     }
 }

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -198,32 +198,41 @@ public class GT_NEI_DefaultHandler
         return currenttip;
     }
 
-    public void drawExtras(int aRecipeIndex) {
-        int tEUt = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mEUt;
-        int tDuration = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mDuration;
-        if (tEUt != 0) {
-            drawText(10, 73, "Total: " + tDuration * tEUt + " EU", -16777216);
-            drawText(10, 83, "Usage: " + tEUt + " EU/t", -16777216);
-            if (this.mRecipeMap.mShowVoltageAmperageInNEI) {
-                drawText(10, 93, "Voltage: " + tEUt / this.mRecipeMap.mAmperage + " EU", -16777216);
-                drawText(10, 103, "Amperage: " + this.mRecipeMap.mAmperage, -16777216);
-            } else {
-                drawText(10, 93, "Voltage: unspecified", -16777216);
-                drawText(10, 103, "Amperage: unspecified", -16777216);
-            }
-        }
-        if (tDuration > 0) {
-            drawText(10, 113, "Time: " + (tDuration < 20 ? "< 1" : Integer.valueOf(tDuration / 20)) + " secs", -16777216);
-        }
-        int tSpecial = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mSpecialValue;
-        if(tSpecial == -100 && GT_Mod.gregtechproxy.mLowGravProcessing){
-        		drawText(10, 123, "Needs Low Gravity", -16777216);
-        	}else if(tSpecial == -200){
-        		drawText(10, 123, "Needs Cleanroom", -16777216);
-        	}else if ((GT_Utility.isStringValid(this.mRecipeMap.mNEISpecialValuePre)) || (GT_Utility.isStringValid(this.mRecipeMap.mNEISpecialValuePost))) {        	
-            drawText(10, 123, this.mRecipeMap.mNEISpecialValuePre + tSpecial * this.mRecipeMap.mNEISpecialValueMultiplier + this.mRecipeMap.mNEISpecialValuePost, -16777216);
-        }
-    }
+	public void drawExtras(int aRecipeIndex) {
+		int tEUt = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mEUt;
+		int tDuration = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mDuration;
+		String[] recipeDesc = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.getNeiDesc();
+		if (recipeDesc == null) {
+			if (tEUt != 0) {
+				drawText(10, 73, "Total: " + tDuration * tEUt + " EU", -16777216);
+				drawText(10, 83, "Usage: " + tEUt + " EU/t", -16777216);
+				if (this.mRecipeMap.mShowVoltageAmperageInNEI) {
+					drawText(10, 93, "Voltage: " + tEUt / this.mRecipeMap.mAmperage + " EU", -16777216);
+					drawText(10, 103, "Amperage: " + this.mRecipeMap.mAmperage, -16777216);
+				} else {
+					drawText(10, 93, "Voltage: unspecified", -16777216);
+					drawText(10, 103, "Amperage: unspecified", -16777216);
+				}
+			}
+			if (tDuration > 0) {
+				drawText(10, 113, "Time: " + (tDuration < 20 ? "< 1" : Integer.valueOf(tDuration / 20)) + " secs", -16777216);
+			}
+			int tSpecial = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mSpecialValue;
+			if (tSpecial == -100 && GT_Mod.gregtechproxy.mLowGravProcessing) {
+				drawText(10, 123, "Needs Low Gravity", -16777216);
+			} else if (tSpecial == -200) {
+				drawText(10, 123, "Needs Cleanroom", -16777216);
+			} else if ((GT_Utility.isStringValid(this.mRecipeMap.mNEISpecialValuePre)) || (GT_Utility.isStringValid(this.mRecipeMap.mNEISpecialValuePost))) {
+				drawText(10, 123, this.mRecipeMap.mNEISpecialValuePre + tSpecial * this.mRecipeMap.mNEISpecialValueMultiplier + this.mRecipeMap.mNEISpecialValuePost, -16777216);
+			}
+		} else {
+			int i = 0;
+			for (String descLine : recipeDesc) {
+				drawText(10, 73 + 10 * i, descLine, -16777216);
+				i++;
+			}
+		}
+	}
 
     public static class GT_RectHandler
             implements IContainerInputHandler, IContainerTooltipHandler {


### PR DESCRIPTION
Expanded the NEI api to allow for custom descriptions, added liquid fuels to the newly created Large Boiler tab

Instead of the default information like total EU or EU usage it is now
possible to provide custom Strings to describe a recipe.

The Large Boiler NEI tab explicitly shows burn times for fuels depending
on the boiler used.
Any liquid fuel added to Diesel Fuels or Semifluid Fuels will
automatically be added to Large Boiler Fuels.