### PR TITLE
Material formula fix

### DIFF
--- a/src/main/java/gregtech/api/objects/MaterialStack.java
+++ b/src/main/java/gregtech/api/objects/MaterialStack.java
@@ -1,7 +1,6 @@
 package gregtech.api.objects;
 
 import gregtech.api.enums.Materials;
-import gregtech.api.util.GT_Log;
 
 public class MaterialStack implements Cloneable {
     public long mAmount;
@@ -34,7 +33,6 @@ public class MaterialStack implements Cloneable {
     @Override
     public String toString() {
          String temp1 = "", temp2 = mMaterial.getToolTip(true), temp3 = "", temp4 = "";
-         System.out.println("EPIK "+mMaterial.mDefaultLocalName+" "+mMaterial.mElement);
          if (mAmount > 1) {
              temp4 = String.valueOf(mAmount);
              if (mMaterial.mMaterialList.size() > 1 || (mMaterial.mMaterialList.size() == 1 && mMaterial.mElement == null)) {

--- a/src/main/java/gregtech/api/objects/MaterialStack.java
+++ b/src/main/java/gregtech/api/objects/MaterialStack.java
@@ -1,6 +1,7 @@
 package gregtech.api.objects;
 
 import gregtech.api.enums.Materials;
+import gregtech.api.util.GT_Log;
 
 public class MaterialStack implements Cloneable {
     public long mAmount;
@@ -33,9 +34,10 @@ public class MaterialStack implements Cloneable {
     @Override
     public String toString() {
          String temp1 = "", temp2 = mMaterial.getToolTip(true), temp3 = "", temp4 = "";
+         System.out.println("EPIK "+mMaterial.mDefaultLocalName+" "+mMaterial.mElement);
          if (mAmount > 1) {
              temp4 = String.valueOf(mAmount);
-             if (mMaterial.mMaterialList.size() > 1) {
+             if (mMaterial.mMaterialList.size() > 1 || (mMaterial.mMaterialList.size() == 1 && mMaterial.mElement == null)) {
                 temp1 = "(";
                 temp3 = ")";
              }


### PR DESCRIPTION
Currently when checking whether brackets are to be put around one of the MaterialStacks in a Materials chemical formula the conditions are:
-Stack size > 1
-Direct stack submaterials > 1

However, this does not detect Materials like Flint, which has exactly one direct submaterial (SiliconDioxide).
For example currently the formula for Diatomite is SiO28Al2O3Fe2O3 instead of (SiO2)8Al2O3Fe2O3.
I added another case that adds brackets when the MaterialStack is made from exactly one compound material.