### PR TITLE
Player detector fix

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -48,6 +48,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     private int oX = 0, oY = 0, oZ = 0, mTimeStatisticsIndex = 0;
     private short mID = 0;
     private long mTickTimer = 0;
+    private String mOwnerName = ""; //Currently only used by PlayerDetector
 
     public BaseMetaPipeEntity() {
     }
@@ -69,6 +70,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
             aNBT.setByte("mColor", mColor);
             aNBT.setByte("mStrongRedstone", mStrongRedstone);
             aNBT.setBoolean("mWorks", !mWorks);
+            aNBT.setString("mOwnerName", mOwnerName);
         } catch (Throwable e) {
             GT_Log.err.println("Encountered CRITICAL ERROR while saving MetaTileEntity, the Chunk whould've been corrupted by now, but I prevented that. Please report immidietly to GregTech Intergalactical!!!");
             e.printStackTrace(GT_Log.err);
@@ -122,6 +124,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
             mColor = aNBT.getByte("mColor");
             mStrongRedstone = aNBT.getByte("mStrongRedstone");
             mWorks = !aNBT.getBoolean("mWorks");
+            mOwnerName = aNBT.getString("mOwnerName");
 
             if (mCoverData.length != 6) mCoverData = new int[]{0, 0, 0, 0, 0, 0};
             if (mCoverSides.length != 6) mCoverSides = new int[]{0, 0, 0, 0, 0, 0};
@@ -829,6 +832,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                     if (GregTech_API.sCovers.containsKey(new GT_ItemStack(tCurrentItem))) {
                         if (GregTech_API.getCoverBehavior(tCurrentItem).isCoverPlaceable(cSide, new GT_ItemStack(tCurrentItem), this) && mMetaTileEntity.allowCoverOnSide(cSide, new GT_ItemStack(tCurrentItem))) {
                             setCoverItemAtSide(cSide, tCurrentItem);
+                            if (GregTech_API.getCoverBehavior(tCurrentItem) instanceof GT_Cover_PlayerDetector) setOwnerName(aPlayer.getDisplayName());
                             if (!aPlayer.capabilities.isCreativeMode) tCurrentItem.stackSize--;
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }
@@ -1101,12 +1105,14 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
     @Override
     public String getOwnerName() {
-        return "Player";
+        if (GT_Utility.isStringInvalid(mOwnerName)) return "Player";
+        return mOwnerName;
     }
 
     @Override
     public String setOwnerName(String aName) {
-        return "Player";
+        if (GT_Utility.isStringInvalid(aName)) return mOwnerName = "Player";
+        return mOwnerName = aName;
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -832,7 +832,6 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                     if (GregTech_API.sCovers.containsKey(new GT_ItemStack(tCurrentItem))) {
                         if (GregTech_API.getCoverBehavior(tCurrentItem).isCoverPlaceable(cSide, new GT_ItemStack(tCurrentItem), this) && mMetaTileEntity.allowCoverOnSide(cSide, new GT_ItemStack(tCurrentItem))) {
                             setCoverItemAtSide(cSide, tCurrentItem);
-                            if (GregTech_API.getCoverBehavior(tCurrentItem) instanceof GT_Cover_PlayerDetector) setOwnerName(aPlayer.getDisplayName());
                             if (!aPlayer.capabilities.isCreativeMode) tCurrentItem.stackSize--;
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }

--- a/src/main/java/gregtech/common/covers/GT_Cover_PlayerDetector.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_PlayerDetector.java
@@ -57,8 +57,8 @@ public class GT_Cover_PlayerDetector extends GT_CoverBehavior {
         if(aCoverVariable <0){aCoverVariable = 2;}
         switch(aCoverVariable) {
             case 0: GT_Utility.sendChatToPlayer(aPlayer, trans("068", "Emit if any Player is close")); break;
-            case 1: GT_Utility.sendChatToPlayer(aPlayer, trans("069", "Emit if other Player is close")); break;
-            case 2: GT_Utility.sendChatToPlayer(aPlayer, trans("070", "Emit if you are close")); break;
+            case 1: GT_Utility.sendChatToPlayer(aPlayer, trans("070", "Emit if you are close")); break;
+            case 2: GT_Utility.sendChatToPlayer(aPlayer, trans("069", "Emit if other Player is close")); break;
         }
         return aCoverVariable;
     }


### PR DESCRIPTION
Revert #1067, that's something I've done wrong.
I make the BaseMetaPipeEntity able to record the placer of the Player Detector, so generally the Detector will work as well as it is put on BaseMetaTileEntity.

Or should we change the ICoverable interface, to make the tiles able to record the placer of the cover on each side?