### PR TITLE
Fixed inventory misalignment when updating 5.09.30 -> 5.09.31

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -60,7 +60,8 @@ import java.util.regex.Pattern;
 
 @Mod(modid = "gregtech", name = "GregTech", version = "MC1710", useMetadata = false, dependencies = "required-after:IC2; after:Forestry; after:PFAAGeologica; after:Thaumcraft; after:Railcraft; after:appliedenergistics2; after:ThermalExpansion; after:TwilightForest; after:harvestcraft; after:magicalcrops; after:BuildCraft|Transport; after:BuildCraft|Silicon; after:BuildCraft|Factory; after:BuildCraft|Energy; after:BuildCraft|Core; after:BuildCraft|Builders; after:GalacticraftCore; after:GalacticraftMars; after:GalacticraftPlanets; after:ThermalExpansion|Transport; after:ThermalExpansion|Energy; after:ThermalExpansion|Factory; after:RedPowerCore; after:RedPowerBase; after:RedPowerMachine; after:RedPowerCompat; after:RedPowerWiring; after:RedPowerLogic; after:RedPowerLighting; after:RedPowerWorld; after:RedPowerControl; after:UndergroundBiomes;")
 public class GT_Mod implements IGT_Mod {
-    public static final int VERSION = 509;
+    public static final int VERSION = 509, SUBVERSION = 31;
+    public static final int TOTAL_VERSION = 1000 * VERSION + SUBVERSION;
     public static final int REQUIRED_IC2 = 624;
     @Mod.Instance("gregtech")
     public static GT_Mod instance;

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -61,7 +61,7 @@ import java.util.regex.Pattern;
 @Mod(modid = "gregtech", name = "GregTech", version = "MC1710", useMetadata = false, dependencies = "required-after:IC2; after:Forestry; after:PFAAGeologica; after:Thaumcraft; after:Railcraft; after:appliedenergistics2; after:ThermalExpansion; after:TwilightForest; after:harvestcraft; after:magicalcrops; after:BuildCraft|Transport; after:BuildCraft|Silicon; after:BuildCraft|Factory; after:BuildCraft|Energy; after:BuildCraft|Core; after:BuildCraft|Builders; after:GalacticraftCore; after:GalacticraftMars; after:GalacticraftPlanets; after:ThermalExpansion|Transport; after:ThermalExpansion|Energy; after:ThermalExpansion|Factory; after:RedPowerCore; after:RedPowerBase; after:RedPowerMachine; after:RedPowerCompat; after:RedPowerWiring; after:RedPowerLogic; after:RedPowerLighting; after:RedPowerWorld; after:RedPowerControl; after:UndergroundBiomes;")
 public class GT_Mod implements IGT_Mod {
     public static final int VERSION = 509, SUBVERSION = 31;
-    public static final int TOTAL_VERSION = 1000 * VERSION + SUBVERSION;
+    public static final int TOTAL_VERSION = calculateTotalGTVersion(VERSION, SUBVERSION);
     public static final int REQUIRED_IC2 = 624;
     @Mod.Instance("gregtech")
     public static GT_Mod instance;
@@ -1163,4 +1163,11 @@ public class GT_Mod implements IGT_Mod {
         }
     }
     
+    public static int calculateTotalGTVersion(int minorVersion){
+    	return calculateTotalGTVersion(VERSION, minorVersion);
+    }
+
+    public static int calculateTotalGTVersion(int majorVersion, int minorVersion){
+    	return majorVersion * 1000 + minorVersion;
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1917,8 +1917,9 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
      */
     private int shiftInventoryIndex(int slotIndex, int nbtVersion){
     	int oldInputSize, newInputSize, oldOutputSize, newOutputSize;
+    	int chemistryUpdateVersion = GT_Mod.calculateTotalGTVersion(509, 31);
     	if (mID >= 211 && mID <= 218) {//Assembler
-    		if (nbtVersion < 509031) {
+    		if (nbtVersion < chemistryUpdateVersion) {
     			oldInputSize = 2;
     			oldOutputSize = 1;
     		} else {
@@ -1927,7 +1928,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     		newInputSize = 6;
     		newOutputSize = 1;
     	} else if (mID >= 421 && mID <= 428){//Chemical Reactor
-    		if (nbtVersion < 509031) {
+    		if (nbtVersion < chemistryUpdateVersion) {
     			oldInputSize = 2;
     			oldOutputSize = 1;
     		} else {
@@ -1936,7 +1937,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     		newInputSize = 2;
     		newOutputSize = 2;
     	} else if (mID >= 531 && mID <= 538) {//Distillery
-    		if (nbtVersion < 509031) {
+    		if (nbtVersion < chemistryUpdateVersion) {
     			oldInputSize = 1;
     			oldOutputSize = 0;
     		} else {

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1911,6 +1911,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
     /**
      * Shifts the machine Inventory index according to the change in Input/Output Slots.
      * This is NOT done automatically. If you want to change slot count for a machine this method needs to be adapted.
+     * Currently this method only works for GT_MetaTileEntity_BasicMachine
      * @param slotIndex The original Inventory index
      * @param nbtVersion The GregTech version in which the original Inventory Index was saved.
      * @return The corrected Inventory index
@@ -1949,10 +1950,10 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         	return slotIndex;    		
     	}
     	int indexShift = 0;
-    	if (slotIndex >= oldInputSize) {
+    	if (slotIndex >= GT_MetaTileEntity_BasicMachine.OTHER_SLOT_COUNT + oldInputSize) {
     		indexShift += newInputSize - oldInputSize;
     	}    	
-    	if (slotIndex >= oldInputSize + oldOutputSize) {
+    	if (slotIndex >= GT_MetaTileEntity_BasicMachine.OTHER_SLOT_COUNT + oldInputSize + oldOutputSize) {
     		indexShift += newOutputSize - oldOutputSize;
     	}
     	return slotIndex + indexShift;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -43,7 +43,7 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
             DID_NOT_FIND_RECIPE = 0,
             FOUND_RECIPE_BUT_DID_NOT_MEET_REQUIREMENTS = 1,
             FOUND_AND_SUCCESSFULLY_USED_RECIPE = 2;
-    private static final int OTHER_SLOT_COUNT = 4;
+    public static final int OTHER_SLOT_COUNT = 4;
     public final ItemStack[] mOutputItems;
     public final int mInputSlotCount, mAmperage;
     public boolean mAllowInputFromOutputSide = false, mFluidTransfer = false, mItemTransfer = false, mHasBeenUpdated = false, mStuttering = false, mCharge = false, mDecharge = false;


### PR DESCRIPTION
I added a new method to BaseMetaTileEntity that shifts the Inventory index according to the change in Input/Output slots.
This fixes FluidStacks ending up in ItemStack slots.

Instrumentally I have also added a new version ID that considers the GT subversion.