### PR TITLE
Fixed bug - isAllowedToPutIntoSlot don't check size of inventory.

### DIFF
--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -505,7 +505,7 @@ public class GT_Utility {
         }
         if (aTileEntity instanceof ISidedInventory && !((ISidedInventory) aTileEntity).canInsertItem(aSlot, aStack, aSide))
             return false;
-        return aTileEntity.isItemValidForSlot(aSlot, aStack);
+        return aSlot < aTileEntity.getSizeInventory() && aTileEntity.isItemValidForSlot(aSlot, aStack);
     }
 
     /**


### PR DESCRIPTION
I for example can insert items in 30 slot of vanilla minecraft chest (that slot exist because internal inventory size is 36, but not available to interact) with roboarms.