### PR TITLE
Stone Dust Rebalance

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -466,15 +466,18 @@ public class GT_Mod implements IGT_Mod {
         if (GregTech_API.sOPStuff.get(ConfigCategories.Recipes.gregtechrecipes, "SolarPanelUV", false)) {
             GT_ModHandler.addCraftingRecipe(ItemList.Cover_SolarPanel_UV.get(1L, new Object[0]), GT_ModHandler.RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.REVERSIBLE, new Object[]{" S ", "STS", " S ", 'S', ItemList.Cover_SolarPanel_ZPM, 'T', ItemList.Transformer_UV_ZPM});
         }
-        if (GregTech_API.sOPStuff.get(ConfigCategories.Recipes.gregtechrecipes, "StoneDustCentrifugation", true)) {
+    	double outputMultiplier = GregTech_API.sOPStuff.get(ConfigCategories.Recipes.gregtechrecipes, "StoneDustOutputMultiplier", 0.6);
+        if (GregTech_API.sOPStuff.get(ConfigCategories.Recipes.gregtechrecipes, "StoneDustCentrifugation", false)) {
+        	int fullChance = (int)(10000 * outputMultiplier);
+        	int[] chances = new int[]{fullChance, fullChance, fullChance, fullChance, fullChance, (int)(5500 * outputMultiplier)};
 			GT_Values.RA.addCentrifugeRecipe(Materials.Stone.getDust(1), GT_Values.NI, GT_Values.NF, GT_Values.NF, 
 					Materials.Quartzite.getDustSmall(1),Materials.PotassiumFeldspar.getDustSmall(1),Materials.Marble.getDustTiny(2),
 					Materials.Biotite.getDustTiny(1), 	Materials.MetalMixture.getDustTiny(1), 		Materials.Sodalite.getDustTiny(1), 
-					new int[]{10000, 10000, 10000, 10000, 10000, 5500}, 480, 30);
+					chances, 500, 72);
 			GT_Values.RA.addCentrifugeRecipe(Materials.MetalMixture.getDust(1), GT_Values.NI, GT_Values.NF, GT_Values.NF, 
 					Materials.BandedIron.getDustSmall(1), 	Materials.Bauxite.getDustSmall(1), Materials.Pyrolusite.getDustTiny(2),
 					Materials.Barite.getDustTiny(1), 		Materials.Chromite.getDustTiny(1), Materials.Ilmenite.getDustTiny(1), 
-					new int[]{10000, 10000, 10000, 10000, 10000, 6000}, 480, 30);
+					new int[]{10000, 10000, 10000, 10000, 10000, 6000}, 500, 120);
         }
         if (gregtechproxy.mSortToTheEnd) {
             try {

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -466,7 +466,7 @@ public class GT_Mod implements IGT_Mod {
         if (GregTech_API.sOPStuff.get(ConfigCategories.Recipes.gregtechrecipes, "SolarPanelUV", false)) {
             GT_ModHandler.addCraftingRecipe(ItemList.Cover_SolarPanel_UV.get(1L, new Object[0]), GT_ModHandler.RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.REVERSIBLE, new Object[]{" S ", "STS", " S ", 'S', ItemList.Cover_SolarPanel_ZPM, 'T', ItemList.Transformer_UV_ZPM});
         }
-    	double outputMultiplier = GregTech_API.sOPStuff.get(ConfigCategories.Recipes.gregtechrecipes, "StoneDustOutputMultiplier", 0.6);
+    	double outputMultiplier = Math.min(GregTech_API.sOPStuff.get(ConfigCategories.Recipes.gregtechrecipes, "StoneDustOutputMultiplier", 0.6), 1.0);
         if (GregTech_API.sOPStuff.get(ConfigCategories.Recipes.gregtechrecipes, "StoneDustCentrifugation", false)) {
         	int fullChance = (int)(10000 * outputMultiplier);
         	int[] chances = new int[]{fullChance, fullChance, fullChance, fullChance, fullChance, (int)(5500 * outputMultiplier)};


### PR DESCRIPTION
In a previous PR I added recipes for centrifuging Stone Dust.
Since those recipes turned out to be too good, I'm rebalancing them now.

The original idea behind the recipes was to allow the centrifugation of Stone with a distribution of elements roughly similar to the one in earth's crust.
Also, the outputs were quantified in such a way that for every 1 Stone Dust put in you would get 1 unit of material out.

However, when I added the recipe I had not realized that pulverizing Cobblestone now yields Stone Dust instead of Sand.
As such, the energy cost I had set for Stone Dust turned out to be too low.
I have increased the enrgy cost for centrifuging Stone Dust: 14,400EU -> 36,000EU.

Furthermore, while I generally liked the idea of 1 unit of Stone Dust resulting in 1 other unit of material, this has turned out to be inconsistent with other recipes.
Generally, any stage in ore processing gives you byproducts equal to 1/9 of the ore.
Since you get 1 Stone Dust as a byproduct from the Ore Washing Plant, it should be equal to one Tiny Pile of material.

I don't think reducing the output of Stone Dust centrifugation to 1/9 of the original value would be a good solution though;
Only ~17% of the outputs you get from centrifuging Stone Dust are actually useful.
Therefore I have reduced the output chances to 60% of the original so that the amount of useful materials equals ~1/9 of the input.
I estimated the following materials to not be useful: Oxygen, Silicon, Hydrogen, Carbon, Calcium, Potassium
One unit of useful material would then cost 324,000EU.

I also added a config that lets you set the output multiplier for Stone Dust.
Stone Dust centrifugation is now disabled by default since it allows for indefinite material generation;
It will only be allowed if the server owner/player explicitly wishes for it.

Below is a table depicting the outputs of the old and new recipes:

| Material | Old recipes | New recipes | Useful materials distribution |
| --- | --- | --- | --- |
| Oxygen | 58.0% | 34.8% | - |
| Silicon | 17.2% | 10.3% | - |
| Aluminium | 6.20% | 3.70% | 35.2% |
| Magnesium | 4.25% | 2.55% | 24.1% |
| Calcium | 3.85% | 2.31% | - |
| Carbon | 3.85% | 2.31% | - |
| Potassium | 2.42% | 1.45% | - |
| Sodium | 2.20% | 1.32% | 12.5% |
| Iron | 1.59% | 0.96% | 9.04% |
| Fluorine | 1.00% | 0.60% | 5.68% |
| Manganese | 0.81% | 0.48% | 4.59% |
| Hydrogen | 0.71% | 0.42% | - |
| Chlorine | 0.55% | 0.33% | 3.12% |
| Titanium | 0.46% | 0.27% | 2.61% |
| Chrome | 0.34% | 0.20% | 1.96% |
| Sulfur | 0.20% | 0.12% | 1.14% |
| Barium | 0.20% | 0.12% | 1.14% |
