### PR TITLE
More Item Pipe Materials

### DIFF
--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -1448,6 +1448,10 @@ public class GT_Loader_MetaTileEntities implements Runnable {
         GT_OreDictUnificator.registerOre(OrePrefixes.pipeRestrictiveLarge.get(Materials.Osmium), new GT_MetaPipeEntity_Item(5638, "GT_Pipe_Restrictive_Osmium_Large", "Large Restrictive Osmium Item Pipe", 0.75F, Materials.Osmium, 16, 204800, true).getStackForm(1L));
         GT_OreDictUnificator.registerOre(OrePrefixes.pipeRestrictiveHuge.get(Materials.Osmium), new GT_MetaPipeEntity_Item(5639, "GT_Pipe_Restrictive_Osmium_Huge", "Huge Restrictive Osmium Item Pipe", 0.875F, Materials.Osmium, 32, 102400, true).getStackForm(1L));
         generateItemPipes(Materials.PolyvinylChloride, Materials.PolyvinylChloride.mName, "PVC", 5640, 4);
+        generateItemPipes(Materials.Tin, Materials.Tin.mName, "Tin", 5646, 1);
+        generateItemPipes(Materials.Nickel, Materials.Nickel.mName, "Nickel", 5652, 1);
+        generateItemPipes(Materials.Cobalt, Materials.Cobalt.mName, "Cobalt", 5658, 2);
+        generateItemPipes(Materials.Aluminium, Materials.Aluminium.mName, "Aluminium", 5664, 2);
 
 
         ItemList.Automation_ChestBuffer_ULV.set(new GT_MetaTileEntity_ChestBuffer(9230, "automation.chestbuffer.tier.00", "Ultra Low Voltage Chest Buffer", 0).getStackForm(1L));

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -1448,7 +1448,7 @@ public class GT_Loader_MetaTileEntities implements Runnable {
         GT_OreDictUnificator.registerOre(OrePrefixes.pipeRestrictiveLarge.get(Materials.Osmium), new GT_MetaPipeEntity_Item(5638, "GT_Pipe_Restrictive_Osmium_Large", "Large Restrictive Osmium Item Pipe", 0.75F, Materials.Osmium, 16, 204800, true).getStackForm(1L));
         GT_OreDictUnificator.registerOre(OrePrefixes.pipeRestrictiveHuge.get(Materials.Osmium), new GT_MetaPipeEntity_Item(5639, "GT_Pipe_Restrictive_Osmium_Huge", "Huge Restrictive Osmium Item Pipe", 0.875F, Materials.Osmium, 32, 102400, true).getStackForm(1L));
         generateItemPipes(Materials.PolyvinylChloride, Materials.PolyvinylChloride.mName, "PVC", 5640, 4);
-        generateItemPipes(Materials.Tin, Materials.Tin.mName, "Tin", 5646, 1);
+        generateItemPipes(Materials.WroughtIron, Materials.WroughtIron.mName, "Wrought Iron", 5646, 1);
         generateItemPipes(Materials.Nickel, Materials.Nickel.mName, "Nickel", 5652, 1);
         generateItemPipes(Materials.Cobalt, Materials.Cobalt.mName, "Cobalt", 5658, 2);
         generateItemPipes(Materials.Aluminium, Materials.Aluminium.mName, "Aluminium", 5664, 2);


### PR DESCRIPTION
I think currently the materials from which you can make Item Pipes are unneccessarily restrictive.
This PR would enable making Item Pipes from the following materials:
-Tin with a base Item Capacity of 1
-Nickel with a base Item Capacity of 1
-Cobalt with a base Item Capacity of 2
-Aluminium with a base Item Capacity of 2
