### PR TITLE
Magic fix

### DIFF
--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
@@ -1,5 +1,6 @@
 package gregtech.common.tileentities.generators;
 
+import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.Loader;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.ConfigCategories;
@@ -38,11 +39,13 @@ public class GT_MetaTileEntity_MagicalEnergyAbsorber extends GT_MetaTileEntity_B
     public static boolean sAllowMultipleEggs = true;
     public static GT_MetaTileEntity_MagicalEnergyAbsorber mActiveSiphon = null;
     public static int sEnergyPerEnderCrystal = 32;
-    public static int sEnergyFromVis = 12800;
+    public static int sEnergyFromVis = 512; //really? this high? no wonder no eu was generating... (it was 12800 at the time)
     public static int sDragonEggEnergyPerTick = 128;
     public static boolean isThaumcraftLoaded;
+    public static boolean tLameMode = false; // if you use this... lame.
     public int mEfficiency;
     public EntityEnderCrystal mTargetedCrystal;
+    //public static int[] VoltageOut = {32, 128,512,2048}; // Because what the fuck even is this code.
 
     public GT_MetaTileEntity_MagicalEnergyAbsorber(int aID, String aName, String aNameRegional, int aTier) {
         super(aID, aName, aNameRegional, aTier, "Feasts on magic close to it", new ITexture[0]);
@@ -109,34 +112,34 @@ public class GT_MetaTileEntity_MagicalEnergyAbsorber extends GT_MetaTileEntity_B
             // Energyzed node
             if (isThaumcraftLoaded) {
                 try {
+                	int multFactor = 2;
+                	if (tLameMode){
+                		multFactor = 10; //Don't do this. Unless you want to be cheaty and lame.
+                	}
                     World tmpWorld = this.getBaseMetaTileEntity().getWorld();
                     int tmpX = this.getBaseMetaTileEntity().getXCoord();
-                    int tmpY = this.getBaseMetaTileEntity().getYCoord();
+                    int tmpY = this.getBaseMetaTileEntity().getYCoord() + 2; //Add 2 because +1 is the node stabiliser and +2 is the node itself
                     int tmpZ = this.getBaseMetaTileEntity().getZCoord();
-                    int fire = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.FIRE, 1000);
+                    int fire = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.FIRE, 1000); // all of these should be 1000
                     int earth = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.EARTH, 1000);
                     int air = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.AIR, 1000);
-                    int destruction = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.ENTROPY, 1000);
+                    int entropy = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.ENTROPY, 1000);
                     int order = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.ORDER, 1000);
                     int water = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.WATER, 1000);
-                    int visEU = (int) (Math.pow(fire, 4) + Math.pow(earth, 4) + Math.pow(air, 4) + Math.pow(destruction, 4) + Math.pow(order, 4) + Math.pow(
-                            water, 4));
-                    int mult = 85;
-                    if (fire > 4)
-                        mult += 15;
-                    if (earth > 4)
-                        mult += 15;
-                    if (air > 4)
-                        mult += 15;
-                    if (destruction > 4)
-                        mult += 15;
-                    if (order > 4)
-                        mult += 15;
-                    if (water > 4)
-                        mult += 15;
-                    visEU = (visEU * mult) / 100;
-                    getBaseMetaTileEntity().increaseStoredEnergyUnits(Math.min(maxEUOutput(), visEU * getEfficiency() / this.sEnergyFromVis), false);
+                    int visEU = (int) (Math.pow(fire, 2) + Math.pow(earth, 2) + Math.pow(air, 2) + Math.pow(entropy, 2) + Math.pow(order, 2) + Math.pow(water, 2));
+                    int mult = 0; //this should make it more dependant on how big your node is
+                    mult += fire * multFactor;
+                    mult += earth * multFactor;
+                    mult += air * multFactor;
+                    mult += entropy * multFactor;
+                    mult += order * multFactor;
+                    mult += water * multFactor;
+                    visEU = (visEU * mult) / 100; 
+                    
+                   getBaseMetaTileEntity().increaseStoredEnergyUnits(Math.min(maxEUOutput(), visEU * getEfficiency() / sEnergyFromVis), false);
+                    
                 } catch (Throwable e) {
+                	
                 }
             }
             // EnderCrystal

--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
@@ -39,13 +39,11 @@ public class GT_MetaTileEntity_MagicalEnergyAbsorber extends GT_MetaTileEntity_B
     public static boolean sAllowMultipleEggs = true;
     public static GT_MetaTileEntity_MagicalEnergyAbsorber mActiveSiphon = null;
     public static int sEnergyPerEnderCrystal = 32;
-    public static int sEnergyFromVis = 512; //really? this high? no wonder no eu was generating... (it was 12800 at the time)
+    public static int sEnergyFromVis = 512;
     public static int sDragonEggEnergyPerTick = 128;
     public static boolean isThaumcraftLoaded;
-    public static boolean tLameMode = false; // if you use this... lame.
     public int mEfficiency;
     public EntityEnderCrystal mTargetedCrystal;
-    //public static int[] VoltageOut = {32, 128,512,2048}; // Because what the fuck even is this code.
 
     public GT_MetaTileEntity_MagicalEnergyAbsorber(int aID, String aName, String aNameRegional, int aTier) {
         super(aID, aName, aNameRegional, aTier, "Feasts on magic close to it", new ITexture[0]);
@@ -113,9 +111,6 @@ public class GT_MetaTileEntity_MagicalEnergyAbsorber extends GT_MetaTileEntity_B
             if (isThaumcraftLoaded) {
                 try {
                 	int multFactor = 2;
-                	if (tLameMode){
-                		multFactor = 10; //Don't do this. Unless you want to be cheaty and lame.
-                	}
                     World tmpWorld = this.getBaseMetaTileEntity().getWorld();
                     int tmpX = this.getBaseMetaTileEntity().getXCoord();
                     int tmpY = this.getBaseMetaTileEntity().getYCoord() + 2; //Add 2 because +1 is the node stabiliser and +2 is the node itself

--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
@@ -1,6 +1,5 @@
 package gregtech.common.tileentities.generators;
 
-import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.Loader;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.ConfigCategories;

--- a/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/tileentities/generators/GT_MetaTileEntity_MagicalEnergyAbsorber.java
@@ -113,7 +113,7 @@ public class GT_MetaTileEntity_MagicalEnergyAbsorber extends GT_MetaTileEntity_B
                 	int multFactor = 2;
                     World tmpWorld = this.getBaseMetaTileEntity().getWorld();
                     int tmpX = this.getBaseMetaTileEntity().getXCoord();
-                    int tmpY = this.getBaseMetaTileEntity().getYCoord() + 2; //Add 2 because +1 is the node stabiliser and +2 is the node itself
+                    int tmpY = this.getBaseMetaTileEntity().getYCoord();
                     int tmpZ = this.getBaseMetaTileEntity().getZCoord();
                     int fire = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.FIRE, 1000); // all of these should be 1000
                     int earth = VisNetHandler.drainVis(tmpWorld, tmpX, tmpY, tmpZ, Aspect.EARTH, 1000);

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -2877,7 +2877,7 @@ if(Loader.isModLoaded("Railcraft")){
         GT_Values.RA.addDefaultPolymerizationRecipes(Materials.Tetrafluoroethylene.mGas, Materials.Tetrafluoroethylene.getCells(1), Materials.Polytetrafluoroethylene.mStandardMoltenFluid);
         
         GT_Values.RA.addChemicalRecipe(                   Materials.Silicon.getDust(1), GT_Utility.getIntegratedCircuit(1), Materials.Chloromethane.getGas(2000), Materials.Dimethyldichlorosilane.getFluid(1000), GT_Values.NI, 240, 96);
-        GT_Values.RA.addChemicalRecipe(                   Materials.Silicon.getDust(1), GT_Utility.getIntegratedCircuit(11), Materials.Chloromethane.getGas(2000), GT_Values.NF, Materials.Dimethyldichlorosilane.getCells(1), 240, 96);
+        GT_Values.RA.addChemicalRecipe(                   Materials.Silicon.getDust(1), GT_Utility.getIntegratedCircuit(11), Materials.Chloromethane.getGas(2000), GT_Values.NF, Materials.Dimethyldichlorosilane.getFluid(1000), 240, 96);
         GT_Values.RA.addChemicalRecipeForBasicMachineOnly(Materials.Silicon.getDust(1), Materials.Chloromethane.getCells(2), GT_Values.NF, Materials.Dimethyldichlorosilane.getFluid(1000), Materials.Empty.getCells(2), GT_Values.NI, 240, 96);
 
         GT_Values.RA.addChemicalRecipe(Materials.Dimethyldichlorosilane.getCells(1), GT_Utility.getIntegratedCircuit(1),  Materials.Water.getFluid(1000),                   Materials.DilutedHydrochloricAcid.getFluid(1000), Materials.Polydimethylsiloxane.getDust(3), Materials.Empty.getCells(1), 240, 96);

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -2877,7 +2877,7 @@ if(Loader.isModLoaded("Railcraft")){
         GT_Values.RA.addDefaultPolymerizationRecipes(Materials.Tetrafluoroethylene.mGas, Materials.Tetrafluoroethylene.getCells(1), Materials.Polytetrafluoroethylene.mStandardMoltenFluid);
         
         GT_Values.RA.addChemicalRecipe(                   Materials.Silicon.getDust(1), GT_Utility.getIntegratedCircuit(1), Materials.Chloromethane.getGas(2000), Materials.Dimethyldichlorosilane.getFluid(1000), GT_Values.NI, 240, 96);
-        GT_Values.RA.addChemicalRecipe(                   Materials.Silicon.getDust(1), GT_Utility.getIntegratedCircuit(11), Materials.Chloromethane.getGas(2000), GT_Values.NF, Materials.Dimethyldichlorosilane.getFluid(1000), 240, 96);
+        GT_Values.RA.addChemicalRecipe(                   Materials.Silicon.getDust(1), GT_Utility.getIntegratedCircuit(11), Materials.Chloromethane.getGas(2000), GT_Values.NF, Materials.Dimethyldichlorosilane.getCells(1), 240, 96);
         GT_Values.RA.addChemicalRecipeForBasicMachineOnly(Materials.Silicon.getDust(1), Materials.Chloromethane.getCells(2), GT_Values.NF, Materials.Dimethyldichlorosilane.getFluid(1000), Materials.Empty.getCells(2), GT_Values.NI, 240, 96);
 
         GT_Values.RA.addChemicalRecipe(Materials.Dimethyldichlorosilane.getCells(1), GT_Utility.getIntegratedCircuit(1),  Materials.Water.getFluid(1000),                   Materials.DilutedHydrochloricAcid.getFluid(1000), Materials.Polydimethylsiloxane.getDust(3), Materials.Empty.getCells(1), 240, 96);


### PR DESCRIPTION
Not really a fix but rebalancing to make it more effective on small nodes.
The reason why it was not generating in the old version was because the energy from vis divisor was set way too high, meaning a node with 60 or so of each aspect was necessary to generate 32 eu per tick. Also, the energy will scale better now, instead of a huge amount of power given when you get more than 4 of each aspect on a node, a small boost will be given to each aspect. This should make it more viable for practical use.