### PR TITLE
[1.10.2]Compressed Block registry rework

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -5,6 +5,7 @@ import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.unification.material.type.DustMaterial;
 import gregtech.api.unification.material.type.FluidMaterial;
 import gregtech.api.unification.material.type.GemMaterial;
+import gregtech.api.unification.material.type.MarkerMaterial;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.material.type.MetalMaterial;
 import gregtech.api.unification.material.type.RoughMaterial;
@@ -41,6 +42,7 @@ public class Materials {
     private static final long EXT_METAL = STD_METAL | GENERATE_ROD | GENERATE_BOLT_SCREW;
     private static final long EXT2_METAL = EXT_METAL | GENERATE_GEAR | GENERATE_FOIL | GENERATE_FINE_WIRE;
 
+    public static MarkerMaterial _NULL = new MarkerMaterial("_null");
     /**
      * Direct Elements
      */

--- a/src/main/java/gregtech/common/blocks/BlockCompressed.java
+++ b/src/main/java/gregtech/common/blocks/BlockCompressed.java
@@ -1,6 +1,7 @@
 package gregtech.common.blocks;
 
 import gregtech.api.GregTechAPI;
+import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.type.*;
 import gregtech.common.blocks.properties.PropertyMaterial;
 import net.minecraft.block.Block;
@@ -27,7 +28,7 @@ public final class BlockCompressed extends DelayedStateBlock {
 
     public final PropertyMaterial variantProperty;
 
-    public BlockCompressed(Collection<? extends Material> materials) {
+    public BlockCompressed(Material[] materials) {
         super(net.minecraft.block.material.Material.IRON);
         setUnlocalizedName("compressed");
         setHardness(5.0f);
@@ -87,9 +88,9 @@ public final class BlockCompressed extends DelayedStateBlock {
 
     @Override
     public void getSubBlocks(CreativeTabs tab, NonNullList<ItemStack> list) {
-        for(IBlockState blockState : blockState.getValidStates()) {
-            list.add(getItem(blockState));
-        }
+    	blockState.getValidStates().stream()
+    		.filter(blockState -> blockState.getValue(variantProperty) != Materials._NULL)
+    		.forEach(blockState -> list.add(getItem(blockState)));
     }
 
     @Override

--- a/src/main/java/gregtech/common/blocks/MetaBlocks.java
+++ b/src/main/java/gregtech/common/blocks/MetaBlocks.java
@@ -3,6 +3,7 @@ package gregtech.common.blocks;
 import gregtech.api.capability.internal.IGregTechTileEntity;
 import gregtech.api.metatileentity.IMetaTileEntity;
 import gregtech.api.metatileentity.PaintableMetaTileEntity;
+import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.type.DustMaterial;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.ore.OrePrefix;
@@ -23,7 +24,7 @@ import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -106,24 +107,26 @@ public class MetaBlocks {
 
         COMPRESSED = new HashMap<>();
         ORES = new HashMap<>();
-        ArrayList<DustMaterial> materialBuffer = new ArrayList<>();
+        Material[] materialBuffer = new Material[16];
+        Arrays.fill(materialBuffer, Materials._NULL);
         int generationIndex = 0;
         for(Material material : Material.MATERIAL_REGISTRY.getObjectsWithIds()) {
             if(material instanceof DustMaterial) {
-                materialBuffer.add((DustMaterial) material);
-                if(materialBuffer.size() == 16) {
-                    createCompressedBlock(materialBuffer, generationIndex);
-                    materialBuffer.clear();
-                    generationIndex++;
-                }
+            	int id = Material.MATERIAL_REGISTRY.getIDForObject(material), index = id / 16;
+            	if (index > generationIndex) {
+            		createCompressedBlock(materialBuffer, generationIndex);
+            		Arrays.fill(materialBuffer, Materials._NULL);
+            	}
+            	if (!OrePrefix.block.isIgnored(material)) {
+            		materialBuffer[id % 16] = material;
+            		generationIndex = index;
+            	}
                 if(material.hasFlag(DustMaterial.MatFlags.GENERATE_ORE)) {
                     createOreBlock((DustMaterial) material);
                 }
             }
         }
-        if(!materialBuffer.isEmpty()) {
-            createCompressedBlock(materialBuffer, generationIndex);
-        }
+        createCompressedBlock(materialBuffer, generationIndex);
 
         MetaTileEntities.init();
 
@@ -131,11 +134,13 @@ public class MetaBlocks {
         MACHINE.setRegistryName("machine");
     }
 
-    private static void createCompressedBlock(Collection<DustMaterial> materials, int index) {
-        materials.removeIf(OrePrefix.block::isIgnored);
+    private static void createCompressedBlock(Material[] materials, int index) {
         BlockCompressed block = new BlockCompressed(materials);
         block.setRegistryName("compressed_" + index);
-        materials.forEach(material -> COMPRESSED.put(material, block));
+        for (Material material : materials) {
+        	if (material instanceof DustMaterial)
+        		COMPRESSED.put((DustMaterial) material, block);
+        }
     }
 
     private static void createOreBlock(DustMaterial material) {

--- a/src/main/java/gregtech/common/blocks/MetaBlocks.java
+++ b/src/main/java/gregtech/common/blocks/MetaBlocks.java
@@ -112,7 +112,8 @@ public class MetaBlocks {
         int generationIndex = 0;
         for(Material material : Material.MATERIAL_REGISTRY.getObjectsWithIds()) {
             if(material instanceof DustMaterial) {
-            	int id = Material.MATERIAL_REGISTRY.getIDForObject(material), index = id / 16;
+            	int id = Material.MATERIAL_REGISTRY.getIDForObject(material);
+            	int index = id / 16;
             	if (index > generationIndex) {
             		createCompressedBlock(materialBuffer, generationIndex);
             		Arrays.fill(materialBuffer, Materials._NULL);


### PR DESCRIPTION
Why you are registering those compressed blocks with the algorithm highly depending on the order of the materials?