### PR TITLE
Output Hatch lock fix

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Output.java
@@ -103,7 +103,7 @@ public class GT_MetaTileEntity_Hatch_Output extends GT_MetaTileEntity_Hatch {
     public void saveNBTData(NBTTagCompound aNBT) {
         super.saveNBTData(aNBT);
         aNBT.setByte("mMode", mMode);
-        aNBT.setString("lockedFluidName", lockedFluidName);
+        aNBT.setString("lockedFluidName", lockedFluidName == null ? "" : lockedFluidName);
     }
 
     @Override


### PR DESCRIPTION
Currently, when an Output Hatch is saved to NBT and no fluid is locked in, the argument for aNBT.setString is null.
While this does not cause a crash it does cause log spam.
This PR adds a check whether lockedFluidName is null when saving the Hatch to NBT.