### PR TITLE
Magneticraft & FMP Dependency

### DIFF
--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -38,6 +38,8 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -606,18 +608,73 @@ public class GT_ModHandler {
     }
 
     public static boolean addMagneticraftRecipe(ItemStack aInput, ItemStack aOutput1, ItemStack aOutput2, int aChance2, ItemStack aOutput3, int aChance3){
-        if(GregTech_API.mMagneticraft && GT_Mod.gregtechproxy.mMagneticraftRecipes){
-          ItemData  tData = GT_OreDictUnificator.getAssociation(aInput);
-          if(tData!=null&&tData.mPrefix!=null){
-            if(tData.mPrefix==OrePrefixes.ore||tData.mPrefix==OrePrefixes.oreBlackgranite||tData.mPrefix==OrePrefixes.oreEndstone||tData.mPrefix==OrePrefixes.oreNetherrack||tData.mPrefix==OrePrefixes.oreRedgranite){
-            	com.cout970.magneticraft.api.access.MgRecipeRegister.registerCrusherRecipe(aInput, aOutput1, aOutput2,(float)((float)aChance2/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent), aOutput3,(float)((float)aChance3/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent));
-          }else if(tData.mPrefix==OrePrefixes.crushed||tData.mPrefix==OrePrefixes.crushedCentrifuged||tData.mPrefix==OrePrefixes.crushedPurified){
-        	  com.cout970.magneticraft.api.access.MgRecipeRegister.registerGrinderRecipe(aInput, aOutput1, aOutput2,(float)((float)aChance2/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent), aOutput3,(float)((float)aChance3/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent));
-          	}
-          }
-        }
-        return true;
-    }
+		if(GregTech_API.mMagneticraft && GT_Mod.gregtechproxy.mMagneticraftRecipes){
+			ItemData  tData = GT_OreDictUnificator.getAssociation(aInput);
+			if(tData!=null&&tData.mPrefix!=null){
+				if(tData.mPrefix==OrePrefixes.ore||tData.mPrefix==OrePrefixes.oreBlackgranite||tData.mPrefix==OrePrefixes.oreEndstone||tData.mPrefix==OrePrefixes.oreNetherrack||tData.mPrefix==OrePrefixes.oreRedgranite){
+					registerMagneticraftCrusherRecipe(aInput, aOutput1, aOutput2,(float)((float)aChance2/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent), aOutput3,(float)((float)aChance3/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent));
+				}else if(tData.mPrefix==OrePrefixes.crushed||tData.mPrefix==OrePrefixes.crushedCentrifuged||tData.mPrefix==OrePrefixes.crushedPurified){
+					registerMagneticraftGrinderRecipe(aInput, aOutput1, aOutput2,(float)((float)aChance2/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent), aOutput3,(float)((float)aChance3/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent));
+				}
+			}
+		}
+		return true;
+	}
+
+	public static boolean registerMagneticraftSifterRecipe(final ItemStack in, final ItemStack out, final ItemStack extra,
+			final float prob) {
+		//Get Magnetiraft Recipe Handler
+				Class cls;
+				try {
+					cls = Class.forName("com.cout970.magneticraft.api.access.MgRecipeRegister");
+					//Get registerCrusherRecipe method from class.
+					Method mCrusher = cls.getDeclaredMethod("registerSifterRecipe", ItemStack.class, ItemStack.class,
+							ItemStack.class, float.class);
+					//Invoke Method
+					return (boolean) mCrusher.invoke(null, in, out, extra, prob);
+
+				}
+				catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+					return false;
+				}
+	}
+
+	public static boolean registerMagneticraftCrusherRecipe(final ItemStack in, final ItemStack out0, final ItemStack out1,
+			final float prob1, final ItemStack out2, final float prob2) {
+		//Get Magnetiraft Recipe Handler
+		Class cls;
+		try {
+			cls = Class.forName("com.cout970.magneticraft.api.access.MgRecipeRegister");
+			//Get registerCrusherRecipe method from class.
+			Method mCrusher = cls.getDeclaredMethod("registerCrusherRecipe", ItemStack.class, ItemStack.class,
+					ItemStack.class, float.class, ItemStack.class, float.class);
+			//Invoke Method
+			return (boolean) mCrusher.invoke(null, in, out0, out1,(float)((float)prob1/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent), out2,(float)((float)prob2/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent));
+
+		}
+		catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			return false;
+		}
+	}
+
+	public static boolean registerMagneticraftGrinderRecipe(final ItemStack in, final ItemStack out0, final ItemStack out1,
+			final float prob1, final ItemStack out2, final float prob2) {
+		//Get Magnetiraft Recipe Handler
+		Class cls;
+		try {
+			cls = Class.forName("com.cout970.magneticraft.api.access.MgRecipeRegister");
+
+			//Get registerGrinderRecipe method from class.
+			Method mGrinder = cls.getDeclaredMethod("registerGrinderRecipe", ItemStack.class, ItemStack.class,
+					ItemStack.class, float.class, ItemStack.class, float.class);
+			//Invoke Method
+			return (boolean) mGrinder.invoke(null, in, out0, out1,(float)((float)prob1/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent), out2,(float)((float)prob2/GT_Mod.gregtechproxy.mMagneticraftBonusOutputPercent));
+
+		}
+		catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			return false;
+		}
+	}
 
     /**
      * Adds a Recipe to the Sawmills of GregTech and ThermalCraft

--- a/src/main/java/gregtech/api/util/GT_ModHandler.java
+++ b/src/main/java/gregtech/api/util/GT_ModHandler.java
@@ -635,6 +635,7 @@ public class GT_ModHandler {
 
 				}
 				catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+					 GT_Log.err.println("WARNING: Bad Reflection into Magneticraft Sifter handler.");
 					return false;
 				}
 	}
@@ -653,6 +654,7 @@ public class GT_ModHandler {
 
 		}
 		catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			 GT_Log.err.println("WARNING: Bad Reflection into Magneticraft Crusher handler.");
 			return false;
 		}
 	}
@@ -672,6 +674,7 @@ public class GT_ModHandler {
 
 		}
 		catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			 GT_Log.err.println("WARNING: Bad Reflection into Magneticraft Grinder handler.");
 			return false;
 		}
 	}

--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrushedOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingCrushedOre.java
@@ -32,13 +32,13 @@ public class ProcessingCrushedOre implements gregtech.api.interfaces.IOreRecipeR
 					case "Amber": case "Diamond": case "FoolsRuby": case "BlueTopaz": case "GarnetRed": case "Topaz": case "Jasper": case "GarnetYellow":
 						GT_Values.RA.addSifterRecipe(GT_Utility.copyAmount(1L, new Object[]{aStack}), new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, tGem, 1L), GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, tGem, 1L), tGem, GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, tGem, 1L), GT_OreDictUnificator.get(OrePrefixes.gemChipped, aMaterial, tGem, 1L), GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, tGem, 1L)}, new int[]{300, 1200, 4500, 1400, 2800, 3500}, 800, 16);
 				        if(GT_Mod.gregtechproxy.mMagneticraftRecipes && GregTech_API.mMagneticraft){
-				        	com.cout970.magneticraft.api.access.MgRecipeRegister.registerSifterRecipe(GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial, tGem, 1), GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, tGem, 1), GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, tGem, 1), 0.2f);
+				        	GT_ModHandler.registerMagneticraftSifterRecipe(GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial, tGem, 1), GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, tGem, 1), GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, tGem, 1), 0.2f);
 				        }
 						break;
 					default:
 						GT_Values.RA.addSifterRecipe(GT_Utility.copyAmount(1L, new Object[]{aStack}), new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.gemExquisite, aMaterial, tGem, 1L), GT_OreDictUnificator.get(OrePrefixes.gemFlawless, aMaterial, tGem, 1L), tGem, GT_OreDictUnificator.get(OrePrefixes.gemFlawed, aMaterial, tGem, 1L), GT_OreDictUnificator.get(OrePrefixes.gemChipped, aMaterial, tGem, 1L), GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, tGem, 1L)}, new int[]{100, 400, 1500, 2000, 4000, 5000}, 800, 16);
 						if(GT_Mod.gregtechproxy.mMagneticraftRecipes && GregTech_API.mMagneticraft){
-							com.cout970.magneticraft.api.access.MgRecipeRegister.registerSifterRecipe(GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial, tGem, 1), GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, tGem, 1), GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, tGem, 1), 0.2f);
+							GT_ModHandler.registerMagneticraftSifterRecipe(GT_OreDictUnificator.get(OrePrefixes.crushedPurified, aMaterial, tGem, 1), GT_OreDictUnificator.get(OrePrefixes.gem, aMaterial, tGem, 1), GT_OreDictUnificator.get(OrePrefixes.dust, aMaterial, tGem, 1), 0.2f);
 				        }
 				}}
 				break;


### PR DESCRIPTION
Moved the 3 different API calls to be reflective, which means Magneticraft is no longer required for Dev.