### PR TITLE
Small lava boiler "calcification" mechanic

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -227,6 +227,7 @@ public class GT_Mod implements IGT_Mod {
         gregtechproxy.mIncreaseDungeonLoot = tMainConfig.get(aTextGeneral, "IncreaseDungeonLoot", true).getBoolean(true);
         gregtechproxy.mAxeWhenAdventure = tMainConfig.get(aTextGeneral, "AdventureModeStartingAxe", true).getBoolean(true);
         gregtechproxy.mHardcoreCables = tMainConfig.get(aTextGeneral, "HardCoreCableLoss", false).getBoolean(false);
+        gregtechproxy.mSmallLavaBoilerEfficiencyLoss = tMainConfig.get(aTextGeneral, "SmallLavaBoilerEfficiencyLoss", true).getBoolean(true);
         gregtechproxy.mSurvivalIntoAdventure = tMainConfig.get(aTextGeneral, "forceAdventureMode", false).getBoolean(false);
         gregtechproxy.mHungerEffect = tMainConfig.get(aTextGeneral, "AFK_Hunger", false).getBoolean(false);
         gregtechproxy.mHardRock = tMainConfig.get(aTextGeneral, "harderstone", false).getBoolean(false);

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -132,6 +132,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     private final DateFormat mDateFormat = DateFormat.getInstance();
     public ArrayList<String> mBufferedPlayerActivity = new ArrayList();
     public boolean mHardcoreCables = false;
+    public boolean mSmallLavaBoilerEfficiencyLoss = true;
     public boolean mDisableVanillaOres = true;
     public boolean mNerfStorageBlocks = true;
     public boolean mHardMachineCasings = true;

--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler_Lava.java
@@ -26,7 +26,7 @@ public class GT_MetaTileEntity_Boiler_Lava
         super(aID, aName, aNameRegional, new String[]{
                 "A Boiler running off Lava",
                 "Produces 600L of Steam per second",
-                "Drops to 200L of Steam per second as byproduct fills",
+                "Drops to 200L of Steam per second as byproduct slot fills",
                 "Clean out byproducts to keep efficiency high",
                 "Causes 20 Pollution per second"});
     }


### PR DESCRIPTION
This patch introduces a new mechanic to the small steel lava boiler, to bring it's performance more in line with the other early game single block boilers.

The boiler will produce on average one impure stone dust per bucket of lava consumed. The stone dust is placed in the output slot. Empty lava buckets are now placed back into the input slot.

The efficiency of the boiler will drop from 100% when the output slot is empty, to 33% when the output slot is full, representing the boiler becoming less efficient as it become clogged with cooled lava residues. The slot can be emptied by hand, and does not require the boiler to be break/replaced.

The reason for this change is that currently the small lava boiler is very powerful early game, and very easy to automate (a single fluid conduit). A single drum of lava from the nether takes about 10 minutes to acquire using a bucket, and generates ~25M EU in this boiler, and requires no further intervention, making lava power both least effort and the most powerful early game option.

Open to balance suggestions regarding minimal efficiency percentage and rate of efficiency loss. Currently it will take about 8 hours continuous use to reach the minimum 33% efficiency, so this represents a very minor nerf to the early game, but does make the single block lava boiler less viable to spam into the midgame.