### PR TITLE
Fixed Mufflers and Large Boiler Fuels.

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -1198,7 +1198,6 @@ public class GT_Mod implements IGT_Mod {
         		GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sulfur, 1),
         		GT_OreDictUnificator.get(ItemList.Block_SSFUEL.get(1, new Object[0])),
         		GT_OreDictUnificator.get(ItemList.Block_MSSFUEL.get(1, new Object[0])),
-        		GT_OreDictUnificator.get(OrePrefixes.bucket, Materials.Lava, 1),
         		GT_OreDictUnificator.get(OrePrefixes.rod, Materials.Blaze, 1));
         if (Loader.isModLoaded("Thaumcraft")) {
         	GT_Recipe.GT_Recipe_Map.sLargeBoilerFakeFuels.addSolidRecipe(GT_ModHandler.getModItem("Thaumcraft", "ItemResource", 1));

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Muffler.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Muffler.java
@@ -54,8 +54,8 @@ public class GT_MetaTileEntity_Hatch_Muffler extends GT_MetaTileEntity_Hatch {
 
     @Override
     public boolean isFacingValid(byte aFacing) {
-        return true;
-    }
+        return aFacing != 0;
+    }    
 
     @Override
     public boolean isAccessAllowed(EntityPlayer aPlayer) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
@@ -44,7 +44,7 @@ public abstract class GT_MetaTileEntity_LargeBoiler
                 "A programmed circuit in the main block throttles the boiler (-1000L/s per config)",
                 "Size(WxHxD): 3x5x3, Controller (Front middle in Fireboxes)",
                 "3x1x3 of " +getCasingMaterial()+ " Firebox Casings (Bottom layer, Min 3)",
-                "3x4x3 of " +getCasingMaterial()+ " Machine Casings/Plated Bricks (Above Fireboxes, hollow, Min 24!)",
+                "3x4x3 of " +getCasingMaterial()+ " " +getCasingBlockType()+ " (Above Fireboxes, hollow, Min 24!)",
                 "1x3x1 of " +getCasingMaterial()+ " Pipe Casings (Inside the Hollow Machine Casings/Plated Bricks)",
                 "1x Fuel Input Hatch/Bus (Any Firebox)",
                 "1x Water Input Hatch (Any Firebox)",
@@ -59,6 +59,8 @@ public abstract class GT_MetaTileEntity_LargeBoiler
     public abstract String getCasingMaterial();
 
     public abstract Block getCasingBlock();
+    
+    public abstract String getCasingBlockType();
 
     public abstract byte getCasingMeta();
 

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler.java
@@ -2,6 +2,7 @@ package gregtech.common.tileentities.machines.multi;
 
 import gregtech.GT_Mod;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.Textures;
 import gregtech.api.gui.GT_GUIContainer_MultiMachine;
 import gregtech.api.interfaces.ITexture;
@@ -9,6 +10,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_MultiBlockBase;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
 import net.minecraft.block.Block;
@@ -136,22 +138,24 @@ public abstract class GT_MetaTileEntity_LargeBoiler
         ArrayList<ItemStack> tInputList = getStoredInputs();
         if (!tInputList.isEmpty()) {
             for (ItemStack tInput : tInputList) {
-                if (GT_Utility.getFluidForFilledItem(tInput, true) == null && (this.mMaxProgresstime = GT_ModHandler.getFuelValue(tInput) / 80) > 0) {
-                    this.excessFuel += GT_ModHandler.getFuelValue(tInput) % 80;
-                    this.mMaxProgresstime += this.excessFuel / 80;
-                    this.excessFuel %= 80;
-                    this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(this.mMaxProgresstime));
-                    this.mEUt = adjustEUtForConfig(getEUt());
-                    this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
-                    this.mOutputItems = new ItemStack[]{GT_Utility.getContainerItem(tInput, true)};
-                    tInput.stackSize -= 1;
-                    updateSlots();
-                    if (this.mEfficiencyIncrease > 5000) {
-                        this.mEfficiencyIncrease = 0;
-                        this.mSuperEfficencyIncrease = 20;
-                    }
-                    return true;
-                }
+				if (tInput != GT_OreDictUnificator.get(OrePrefixes.bucket, Materials.Lava, 1)){
+					if (GT_Utility.getFluidForFilledItem(tInput, true) == null && (this.mMaxProgresstime = GT_ModHandler.getFuelValue(tInput) / 80) > 0) {
+                    	this.excessFuel += GT_ModHandler.getFuelValue(tInput) % 80;
+                    	this.mMaxProgresstime += this.excessFuel / 80;
+                    	this.excessFuel %= 80;
+                    	this.mMaxProgresstime = adjustBurnTimeForConfig(runtimeBoost(this.mMaxProgresstime));
+                    	this.mEUt = adjustEUtForConfig(getEUt());
+                    	this.mEfficiencyIncrease = this.mMaxProgresstime * getEfficiencyIncrease();
+                    	this.mOutputItems = new ItemStack[]{GT_Utility.getContainerItem(tInput, true)};
+                    	tInput.stackSize -= 1;
+                    	updateSlots();
+                    	if (this.mEfficiencyIncrease > 5000) {
+                        	this.mEfficiencyIncrease = 0;
+                        	this.mSuperEfficencyIncrease = 20;
+                    	}
+                    	return true;
+                	}
+				}
             }
         }
         this.mMaxProgresstime = 0;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Bronze.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Bronze.java
@@ -23,6 +23,11 @@ public class GT_MetaTileEntity_LargeBoiler_Bronze
     	return "Bronze";
     }
 
+	@Override
+	public String getCasingBlockType() {
+		return "Plated Bricks";
+	}
+
     public Block getCasingBlock() {
         return GregTech_API.sBlockCasings1;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Steel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Steel.java
@@ -23,6 +23,11 @@ public class GT_MetaTileEntity_LargeBoiler_Steel
     	return "Steel";
     }
 
+	@Override
+	public String getCasingBlockType() {
+		return "Machine Casings";
+	}
+
     public Block getCasingBlock() {
         return GregTech_API.sBlockCasings2;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_Titanium.java
@@ -23,6 +23,11 @@ public class GT_MetaTileEntity_LargeBoiler_Titanium
     	return "Titanium";
     }
 
+	@Override
+	public String getCasingBlockType() {
+		return "Machine Casings";
+	}
+
     public Block getCasingBlock() {
         return GregTech_API.sBlockCasings4;
     }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_LargeBoiler_TungstenSteel.java
@@ -23,6 +23,11 @@ public class GT_MetaTileEntity_LargeBoiler_TungstenSteel
     	return "TungstenSteel";
     }
 
+	@Override
+	public String getCasingBlockType() {
+		return "Machine Casings";
+	}
+
     public Block getCasingBlock() {
         return GregTech_API.sBlockCasings4;
     }


### PR DESCRIPTION
Mufflers can no longer face downwards, into a machine.
This abuse allowed machines to check inside themselves for air.

Large Boilers cannot take Lava anymore, as originally intended.