### PR TITLE
GT6 cable quality of life improvements

### DIFF
--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -52,186 +52,191 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      * 14 = BaseMetaPipeEntity, Axe lvl 2 to dismantle
      * 15 = BaseMetaPipeEntity, Axe lvl 3 to dismantle
      */
-    public byte getTileEntityBaseType();
+    byte getTileEntityBaseType();
 
     /**
      * @param aTileEntity is just because the internal Variable "mBaseMetaTileEntity" is set after this Call.
      * @return a newly created and ready MetaTileEntity
      */
-    public IMetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity);
+    IMetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity);
 
     /**
      * @return an ItemStack representing this MetaTileEntity.
      */
-    public ItemStack getStackForm(long aAmount);
+    ItemStack getStackForm(long aAmount);
 
     /**
      * new getter for the BaseMetaTileEntity, which restricts usage to certain Functions.
      */
-    public IGregTechTileEntity getBaseMetaTileEntity();
+    IGregTechTileEntity getBaseMetaTileEntity();
 
     /**
      * Sets the BaseMetaTileEntity of this
      */
-    public void setBaseMetaTileEntity(IGregTechTileEntity aBaseMetaTileEntity);
+    void setBaseMetaTileEntity(IGregTechTileEntity aBaseMetaTileEntity);
 
     /**
      * when placing a Machine in World, to initialize default Modes. aNBT can be null!
      */
-    public void initDefaultModes(NBTTagCompound aNBT);
+    void initDefaultModes(NBTTagCompound aNBT);
 
     /**
      * ^= writeToNBT
      */
-    public void saveNBTData(NBTTagCompound aNBT);
+    void saveNBTData(NBTTagCompound aNBT);
 
     /**
      * ^= readFromNBT
      */
-    public void loadNBTData(NBTTagCompound aNBT);
+    void loadNBTData(NBTTagCompound aNBT);
 
     /**
      * Adds the NBT-Information to the ItemStack, when being dismanteled properly
      * Used to store Machine specific Upgrade Data.
      */
-    public void setItemNBT(NBTTagCompound aNBT);
+    void setItemNBT(NBTTagCompound aNBT);
 
     /**
      * Called in the registered MetaTileEntity when the Server starts, to reset static variables
      */
-    public void onServerStart();
+    void onServerStart();
 
     /**
      * Called in the registered MetaTileEntity when the Server ticks a World the first time, to load things from the World Save
      */
-    public void onWorldLoad(File aSaveDirectory);
+    void onWorldLoad(File aSaveDirectory);
 
     /**
      * Called in the registered MetaTileEntity when the Server stops, to save the Game.
      */
-    public void onWorldSave(File aSaveDirectory);
+    void onWorldSave(File aSaveDirectory);
 
     /**
      * Called to set Configuration values for this MetaTileEntity.
      * Use aConfig.get(ConfigCategories.machineconfig, "MetaTileEntityName.Ability", DEFAULT_VALUE); to set the Values.
      */
-    public void onConfigLoad(GT_Config aConfig);
+    void onConfigLoad(GT_Config aConfig);
 
     /**
      * If a Cover of that Type can be placed on this Side.
      * Also Called when the Facing of the Block Changes and a Cover is on said Side.
      */
-    public boolean allowCoverOnSide(byte aSide, GT_ItemStack aStack);
+    boolean allowCoverOnSide(byte aSide, GT_ItemStack aStack);
 
     /**
      * When a Player rightclicks the Facing with a Screwdriver.
      */
-    public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
+    void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
 
     /**
      * When a Player rightclicks the Facing with a Wrench.
      */
-    public boolean onWrenchRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
+    boolean onWrenchRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
 
     /**
      * When a Player rightclicks the Facing with a wire cutter.
      */
-    public boolean onWireCutterRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
+    boolean onWireCutterRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
+
+    /**
+     * When a Player rightclicks the Facing with a soldering iron.
+     */
+    boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
 
     /**
      * Called right before this Machine explodes
      */
-    public void onExplosion();
+    void onExplosion();
 
     /**
      * The First processed Tick which was passed to this MetaTileEntity
      */
-    public void onFirstTick(IGregTechTileEntity aBaseMetaTileEntity);
+    void onFirstTick(IGregTechTileEntity aBaseMetaTileEntity);
 
     /**
      * The Tick before all the generic handling happens, what gives a slightly faster reaction speed.
      * Don't use this if you really don't need to. @onPostTick is better suited for ticks.
      * This happens still after the Cover handling.
      */
-    public void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick);
+    void onPreTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick);
 
     /**
      * The Tick after all the generic handling happened.
      * Recommended to use this like updateEntity.
      */
-    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick);
+    void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick);
 
     /**
      * Called when this MetaTileEntity gets (intentionally) disconnected from the BaseMetaTileEntity.
      * Doesn't get called when this thing is moved by Frames or similar hacks.
      */
-    public void inValidate();
+    void inValidate();
 
     /**
      * Called when the BaseMetaTileEntity gets invalidated, what happens right before the @inValidate above gets called
      */
-    public void onRemoval();
+    void onRemoval();
 
     /**
      * @param aFacing
      * @return if aFacing would be a valid Facing for this Device. Used for wrenching.
      */
-    public boolean isFacingValid(byte aFacing);
+    boolean isFacingValid(byte aFacing);
 
     /**
      * @return the Server Side Container
      */
-    public Object getServerGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity);
+    Object getServerGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity);
 
     /**
      * @return the Client Side GUI Container
      */
-    public Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity);
+    Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity);
 
     /**
      * From new ISidedInventory
      */
-    public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack);
+    boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack);
 
     /**
      * From new ISidedInventory
      */
-    public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack);
+    boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack);
 
     /**
      * @return if aIndex is a valid Slot. false for things like HoloSlots. Is used for determining if an Item is dropped upon Block destruction and for Inventory Access Management
      */
-    public boolean isValidSlot(int aIndex);
+    boolean isValidSlot(int aIndex);
 
     /**
      * @return if aIndex can be set to Zero stackSize, when being removed.
      */
-    public boolean setStackToZeroInsteadOfNull(int aIndex);
+    boolean setStackToZeroInsteadOfNull(int aIndex);
 
     /**
      * If this Side can connect to inputting pipes
      */
-    public boolean isLiquidInput(byte aSide);
+    boolean isLiquidInput(byte aSide);
 
     /**
      * If this Side can connect to outputting pipes
      */
-    public boolean isLiquidOutput(byte aSide);
+    boolean isLiquidOutput(byte aSide);
 
     /**
      * Just an Accessor for the Name variable.
      */
-    public String getMetaName();
+    String getMetaName();
 
     /**
      * @return true if the Machine can be accessed
      */
-    public boolean isAccessAllowed(EntityPlayer aPlayer);
+    boolean isAccessAllowed(EntityPlayer aPlayer);
 
     /**
      * When a Machine Update occurs
      */
-    public void onMachineBlockUpdate();
+    void onMachineBlockUpdate();
 
     /**
      * a Player rightclicks the Machine
@@ -239,18 +244,18 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      *
      * @return
      */
-    public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer, byte aSide, float aX, float aY, float aZ);
+    boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer, byte aSide, float aX, float aY, float aZ);
 
     /**
      * a Player leftclicks the Machine
      * Sneaky leftclicks are getting passed to this unlike with the rightclicks.
      */
-    public void onLeftclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer);
+    void onLeftclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer);
 
     /**
      * Called Clientside with the Data got from @getUpdateData
      */
-    public void onValueUpdate(byte aValue);
+    void onValueUpdate(byte aValue);
 
     /**
      * return a small bit of Data, like a secondary Facing for example with this Function, for the Client.
@@ -259,50 +264,50 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      * <p/>
      * If you just want to have an Active/Redstone State then set the Active State inside the BaseMetaTileEntity instead.
      */
-    public byte getUpdateData();
+    byte getUpdateData();
 
     /**
      * For the rare case you need this Function
      */
-    public void receiveClientEvent(byte aEventID, byte aValue);
+    void receiveClientEvent(byte aEventID, byte aValue);
 
     /**
      * Called to actually play the Sound.
      * Do not insert Client/Server checks. That is already done for you.
      * Do not use @playSoundEffect, Minecraft doesn't like that at all. Use @playSound instead.
      */
-    public void doSound(byte aIndex, double aX, double aY, double aZ);
+    void doSound(byte aIndex, double aX, double aY, double aZ);
 
-    public void startSoundLoop(byte aIndex, double aX, double aY, double aZ);
+    void startSoundLoop(byte aIndex, double aX, double aY, double aZ);
 
-    public void stopSoundLoop(byte aValue, double aX, double aY, double aZ);
-
-    /**
-     * Sends the Event for the Sound Triggers, only usable Server Side!
-     */
-    public void sendSound(byte aIndex);
+    void stopSoundLoop(byte aValue, double aX, double aY, double aZ);
 
     /**
      * Sends the Event for the Sound Triggers, only usable Server Side!
      */
-    public void sendLoopStart(byte aIndex);
+    void sendSound(byte aIndex);
 
     /**
      * Sends the Event for the Sound Triggers, only usable Server Side!
      */
-    public void sendLoopEnd(byte aIndex);
+    void sendLoopStart(byte aIndex);
+
+    /**
+     * Sends the Event for the Sound Triggers, only usable Server Side!
+     */
+    void sendLoopEnd(byte aIndex);
 
     /**
      * Called when the Machine explodes, override Explosion Code here.
      *
      * @param aExplosionPower
      */
-    public void doExplosion(long aExplosionPower);
+    void doExplosion(long aExplosionPower);
 
     /**
      * If this is just a simple Machine, which can be wrenched at 100%
      */
-    public boolean isSimpleMachine();
+    boolean isSimpleMachine();
 
     /**
      * If there should be a Lag Warning if something laggy happens during this Tick.
@@ -310,22 +315,22 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      * The Advanced Pump uses this to not cause the Lag Message, while it scans for all close Fluids.
      * The Item Pipes and Retrievers neither send this Message, when scanning for Pipes.
      */
-    public boolean doTickProfilingMessageDuringThisTick();
+    boolean doTickProfilingMessageDuringThisTick();
 
     /**
      * returns the DebugLog
      */
-    public ArrayList<String> getSpecialDebugInfo(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer, int aLogLevel, ArrayList<String> aList);
+    ArrayList<String> getSpecialDebugInfo(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer, int aLogLevel, ArrayList<String> aList);
 
     /**
      * get a small Description
      */
-    public String[] getDescription();
+    String[] getDescription();
 
     /**
      * In case the Output Voltage varies.
      */
-    public String getSpecialVoltageToolTip();
+    String getSpecialVoltageToolTip();
 
     /**
      * Icon of the Texture. If this returns null then it falls back to getTextureIndex.
@@ -336,7 +341,7 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      * @param aActive     if the Machine is currently active (use this instead of calling mBaseMetaTileEntity.mActive!!!). Note: In case of Pipes this means if this Side is connected to something or not.
      * @param aRedstone   if the Machine is currently outputting a RedstoneSignal (use this instead of calling mBaseMetaTileEntity.mRedstone!!!)
      */
-    public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex, boolean aActive, boolean aRedstone);
+    ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex, boolean aActive, boolean aRedstone);
 
     /**
      * The Textures used for the Item rendering. Return null if you want the regular 3D Block Rendering.
@@ -350,55 +355,55 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
      * @param aBlockIconRegister The Block Icon Register
      */
     @SideOnly(Side.CLIENT)
-    public void registerIcons(IIconRegister aBlockIconRegister);
+    void registerIcons(IIconRegister aBlockIconRegister);
 
     /**
      * @return true if you override the Rendering.
      */
     @SideOnly(Side.CLIENT)
-    public boolean renderInInventory(Block aBlock, int aMeta, RenderBlocks aRenderer);
+    boolean renderInInventory(Block aBlock, int aMeta, RenderBlocks aRenderer);
 
     /**
      * @return true if you override the Rendering.
      */
     @SideOnly(Side.CLIENT)
-    public boolean renderInWorld(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, RenderBlocks aRenderer);
+    boolean renderInWorld(IBlockAccess aWorld, int aX, int aY, int aZ, Block aBlock, RenderBlocks aRenderer);
 
     /**
      * Gets the Output for the comparator on the given Side
      */
-    public byte getComparatorValue(byte aSide);
+    byte getComparatorValue(byte aSide);
 
-    public float getExplosionResistance(byte aSide);
+    float getExplosionResistance(byte aSide);
 
-    public String[] getInfoData();
+    String[] getInfoData();
 
-    public boolean isGivingInformation();
+    boolean isGivingInformation();
 
-    public ItemStack[] getRealInventory();
+    ItemStack[] getRealInventory();
 
-    public boolean connectsToItemPipe(byte aSide);
+    boolean connectsToItemPipe(byte aSide);
 
-    public void onColorChangeServer(byte aColor);
+    void onColorChangeServer(byte aColor);
 
-    public void onColorChangeClient(byte aColor);
+    void onColorChangeClient(byte aColor);
 
-    public int getLightOpacity();
+    int getLightOpacity();
     
-    public boolean allowGeneralRedstoneOutput();
+    boolean allowGeneralRedstoneOutput();
 
-    public void addCollisionBoxesToList(World aWorld, int aX, int aY, int aZ, AxisAlignedBB inputAABB, List<AxisAlignedBB> outputAABB, Entity collider);
+    void addCollisionBoxesToList(World aWorld, int aX, int aY, int aZ, AxisAlignedBB inputAABB, List<AxisAlignedBB> outputAABB, Entity collider);
 
-    public AxisAlignedBB getCollisionBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ);
+    AxisAlignedBB getCollisionBoundingBoxFromPool(World aWorld, int aX, int aY, int aZ);
 
-    public void onEntityCollidedWithBlock(World aWorld, int aX, int aY, int aZ, Entity collider);
+    void onEntityCollidedWithBlock(World aWorld, int aX, int aY, int aZ, Entity collider);
 
     /**
      * The onCreated Function of the Item Class redirects here
      */
-    public void onCreated(ItemStack aStack, World aWorld, EntityPlayer aPlayer);
+    void onCreated(ItemStack aStack, World aWorld, EntityPlayer aPlayer);
     
-    public boolean hasAlternativeModeText();
+    boolean hasAlternativeModeText();
     
-    public String getAlternativeModeText();
+    String getAlternativeModeText();
 }

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -134,6 +134,16 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
     public boolean onWrenchRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
 
     /**
+     * When a Player rightclicks the Facing with a wire cutter.
+     */
+    public boolean onWireCutterRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
+
+    /**
+     * When a Player rightclicks the Facing with a soldering iron.
+     */
+    public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
+     
+    /**
      * Called right before this Machine explodes
      */
     public void onExplosion();

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntity.java
@@ -139,11 +139,6 @@ public interface IMetaTileEntity extends ISidedInventory, IFluidTank, IFluidHand
     public boolean onWireCutterRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
 
     /**
-     * When a Player rightclicks the Facing with a soldering iron.
-     */
-    public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ);
-     
-    /**
      * Called right before this Machine explodes
      */
     public void onExplosion();

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -818,14 +818,17 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
 
                 if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWireCutterList)) {
                     if (mMetaTileEntity.onWireCutterRightClick(aSide, tSide, aPlayer, aX, aY, aZ)) {
-                        GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 1000, aPlayer);
+                        //logic handled internally
                         GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                     }
                     return true;
                 }
 
                 if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sSolderingToolList)) {
-                	if (GT_ModHandler.useSolderingIron(tCurrentItem, aPlayer)) {
+                	if (mMetaTileEntity.onSolderingToolRightClick(aSide, tSide, aPlayer, aX, aY, aZ)) {
+                	    //logic handled internally
+                        GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(103), 1.0F, -1, xCoord, yCoord, zCoord);
+                    } else if (GT_ModHandler.useSolderingIron(tCurrentItem, aPlayer)) {
                         mStrongRedstone ^= (1 << tSide);
                         GT_Utility.sendChatToPlayer(aPlayer, trans("091","Redstone Output at Side ") + tSide + trans("092"," set to: ") + ((mStrongRedstone & (1 << tSide)) != 0 ? trans("093","Strong") : trans("094","Weak")));
                         GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(103), 3.0F, -1, xCoord, yCoord, zCoord);

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -825,10 +825,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
                 }
 
                 if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sSolderingToolList)) {
-                	if (mMetaTileEntity.onSolderingToolRightClick(aSide, tSide, aPlayer, aX, aY, aZ)) {
-                        GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 500, aPlayer);
-                        GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
-                    } else if (GT_ModHandler.useSolderingIron(tCurrentItem, aPlayer)) {
+                	if (GT_ModHandler.useSolderingIron(tCurrentItem, aPlayer)) {
                         mStrongRedstone ^= (1 << tSide);
                         GT_Utility.sendChatToPlayer(aPlayer, trans("091","Redstone Output at Side ") + tSide + trans("092"," set to: ") + ((mStrongRedstone & (1 << tSide)) != 0 ? trans("093","Strong") : trans("094","Weak")));
                         GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(103), 3.0F, -1, xCoord, yCoord, zCoord);

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1308,7 +1308,10 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
 
                     if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sSolderingToolList)) {
                         byte tSide = GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ);
-                        if (GT_ModHandler.useSolderingIron(tCurrentItem, aPlayer)) {
+                        if (mMetaTileEntity.onSolderingToolRightClick(aSide, tSide, aPlayer, aX, aY, aZ)) {
+                            //logic handled internally
+                            GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(103), 1.0F, -1, xCoord, yCoord, zCoord);
+                        } else if (GT_ModHandler.useSolderingIron(tCurrentItem, aPlayer)) {
                             mStrongRedstone ^= (1 << tSide);
                             GT_Utility.sendChatToPlayer(aPlayer, trans("091","Redstone Output at Side ") + tSide + trans("092"," set to: ") + ((mStrongRedstone & (1 << tSide)) != 0 ? trans("093","Strong") : trans("094","Weak")));
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(103), 3.0F, -1, xCoord, yCoord, zCoord);
@@ -1319,7 +1322,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                     if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWireCutterList)) {
                     	byte tSide = GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ);
                         if (mMetaTileEntity.onWireCutterRightClick(aSide, tSide, aPlayer, aX, aY, aZ)) {
-                            GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 1000, aPlayer);
+                            //logic handled internally
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }
                         return true;

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1312,6 +1312,18 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                             mStrongRedstone ^= (1 << tSide);
                             GT_Utility.sendChatToPlayer(aPlayer, trans("091","Redstone Output at Side ") + tSide + trans("092"," set to: ") + ((mStrongRedstone & (1 << tSide)) != 0 ? trans("093","Strong") : trans("094","Weak")));
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(103), 3.0F, -1, xCoord, yCoord, zCoord);
+                        } else if (mMetaTileEntity.onSolderingToolRightClick(aSide, tSide, aPlayer, aX, aY, aZ)) {
+                            GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 500, aPlayer);
+                            GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
+                        } 
+                        return true;
+                    }
+                    
+                    if (GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWireCutterList)) {
+                    	byte tSide = GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ);
+                        if (mMetaTileEntity.onWireCutterRightClick(aSide, tSide, aPlayer, aX, aY, aZ)) {
+                            GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 1000, aPlayer);
+                            GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         }
                         return true;
                     }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -1312,9 +1312,6 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
                             mStrongRedstone ^= (1 << tSide);
                             GT_Utility.sendChatToPlayer(aPlayer, trans("091","Redstone Output at Side ") + tSide + trans("092"," set to: ") + ((mStrongRedstone & (1 << tSide)) != 0 ? trans("093","Strong") : trans("094","Weak")));
                             GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(103), 3.0F, -1, xCoord, yCoord, zCoord);
-                        } else if (mMetaTileEntity.onSolderingToolRightClick(aSide, tSide, aPlayer, aX, aY, aZ)) {
-                            GT_ModHandler.damageOrDechargeItem(tCurrentItem, 1, 500, aPlayer);
-                            GT_Utility.sendSoundToPlayers(worldObj, GregTech_API.sSoundList.get(100), 1.0F, -1, xCoord, yCoord, zCoord);
                         } 
                         return true;
                     }

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -211,11 +211,6 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
     }
 
     @Override
-    public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-        return false;
-    }
-
-    @Override
     public void onExplosion() {/*Do nothing*/}
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -205,10 +205,12 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
         return false;
     }
 
+    @Override
     public boolean onWireCutterRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         return false;
     }
 
+    @Override
     public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         return false;
     }

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -211,6 +211,11 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
     }
 
     @Override
+    public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        return false;
+    }
+
+    @Override
     public void onExplosion() {/*Do nothing*/}
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -165,16 +165,26 @@ public abstract class MetaTileEntity implements IMetaTileEntity {
 
     @Override
     public boolean onWireCutterRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        if(!aPlayer.isSneaking()) return false;
 		byte tSide = GT_Utility.getOppositeSide(aWrenchingSide);
 		TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aWrenchingSide);
-
-		if(tTileEntity != null && (tTileEntity instanceof IGregTechTileEntity) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof GT_MetaPipeEntity_Cable))
-		{
+        if (tTileEntity != null && (tTileEntity instanceof IGregTechTileEntity) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof GT_MetaPipeEntity_Cable)) {
 			// The tile entity we're facing is a cable, let's try to connect to it
-			return ((GT_MetaPipeEntity_Cable)((IGregTechTileEntity) tTileEntity).getMetaTileEntity()).onWireCutterRightClick(aWrenchingSide, tSide, aPlayer, aX, aY, aZ);
+            return ((IGregTechTileEntity) tTileEntity).getMetaTileEntity().onWireCutterRightClick(aWrenchingSide, tSide, aPlayer, aX, aY, aZ);
+        }
+        return false;
 		}
 		
-		return true;
+    @Override
+    public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        if(!aPlayer.isSneaking()) return false;
+        byte tSide = GT_Utility.getOppositeSide(aWrenchingSide);
+        TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aWrenchingSide);
+        if (tTileEntity != null && (tTileEntity instanceof IGregTechTileEntity) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof GT_MetaPipeEntity_Cable)) {
+            // The tile entity we're facing is a cable, let's try to connect to it
+            return ((IGregTechTileEntity) tTileEntity).getMetaTileEntity().onSolderingToolRightClick(aWrenchingSide, tSide, aPlayer, aX, aY, aZ);
+        }
+        return false;
     }
         
     @Override

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -5,6 +5,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaPipeEntity_Cable;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.util.GT_Config;
 import gregtech.api.util.GT_LanguageManager;
@@ -19,6 +20,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -161,6 +163,33 @@ public abstract class MetaTileEntity implements IMetaTileEntity {
         return false;
     }
 
+    @Override
+    public boolean onWireCutterRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+		byte tSide = GT_Utility.getOppositeSide(aWrenchingSide);
+		TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aWrenchingSide);
+
+		if(tTileEntity != null && (tTileEntity instanceof IGregTechTileEntity) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof GT_MetaPipeEntity_Cable))
+		{
+			// The tile entity we're facing is a cable, let's try to connect to it
+			return ((GT_MetaPipeEntity_Cable)((IGregTechTileEntity) tTileEntity).getMetaTileEntity()).onWireCutterRightClick(aWrenchingSide, tSide, aPlayer, aX, aY, aZ);
+		}
+		
+		return true;
+    }
+
+    @Override
+    public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+		byte tSide = GT_Utility.getOppositeSide(aWrenchingSide);
+		TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aWrenchingSide);
+		if(tTileEntity != null && (tTileEntity instanceof IGregTechTileEntity) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof GT_MetaPipeEntity_Cable))
+		{
+			// The tile entity we're facing is a cable, let's try to connect to it
+			return ((GT_MetaPipeEntity_Cable)((IGregTechTileEntity) tTileEntity).getMetaTileEntity()).onSolderingToolRightClick(aWrenchingSide, tSide, aPlayer, aX, aY, aZ);
+		}
+		
+		return true;
+    }
+        
     @Override
     public void onExplosion() {/*Do nothing*/}
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -176,19 +176,6 @@ public abstract class MetaTileEntity implements IMetaTileEntity {
 		
 		return true;
     }
-
-    @Override
-    public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-		byte tSide = GT_Utility.getOppositeSide(aWrenchingSide);
-		TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aWrenchingSide);
-		if(tTileEntity != null && (tTileEntity instanceof IGregTechTileEntity) && (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof GT_MetaPipeEntity_Cable))
-		{
-			// The tile entity we're facing is a cable, let's try to connect to it
-			return ((GT_MetaPipeEntity_Cable)((IGregTechTileEntity) tTileEntity).getMetaTileEntity()).onSolderingToolRightClick(aWrenchingSide, tSide, aPlayer, aX, aY, aZ);
-		}
-		
-		return true;
-    }
         
     @Override
     public void onExplosion() {/*Do nothing*/}

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -2,6 +2,7 @@ package gregtech.api.metatileentity.implementations;
 
 import cofh.api.energy.IEnergyReceiver;
 import gregtech.GT_Mod;
+import static gregtech.api.enums.GT_Values.D1;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.Materials;
@@ -16,9 +17,12 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Client;
+import gregtech.common.covers.GT_Cover_SolarPanel;
 import ic2.api.energy.tile.IEnergySink;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -140,7 +144,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
     @Override
     public long injectEnergyUnits(byte aSide, long aVoltage, long aAmperage) {
-    	if (!isConnectedAtSide(aSide))
+    	if (!isConnectedAtSide(aSide) && aSide != 6)
     		return 0;
         if (!getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsEnergyIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity()))
             return 0;
@@ -149,7 +153,7 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
     @Override
     public long transferElectricity(byte aSide, long aVoltage, long aAmperage, ArrayList<TileEntity> aAlreadyPassedTileEntityList) {
-    	if (!isConnectedAtSide(aSide))
+    	if (!isConnectedAtSide(aSide) && aSide != 6)
     		return 0;
         long rUsedAmperes = 0;
         aVoltage -= mCableLossPerMeter;
@@ -271,29 +275,61 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 		if (aSide >= 6) return rConnect;
 		byte tSide = GT_Utility.getOppositeSide(aSide);
 		TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aSide);
-		if (tTileEntity != null) {
-			if (getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).alwaysLookConnected(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity())
-					|| getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsEnergyIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity())
-					|| getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsEnergyOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity())) {
-	            if (tTileEntity instanceof IColoredTileEntity) {
-	                if (getBaseMetaTileEntity().getColorization() >= 0) {
-	                    byte tColor = ((IColoredTileEntity) tTileEntity).getColorization();
-	                    if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization())
-	                    	return rConnect;
-	                }
-	            }
-	            if ((tTileEntity instanceof IEnergyConnected && (((IEnergyConnected) tTileEntity).inputEnergyFrom(tSide) || ((IEnergyConnected) tTileEntity).outputsEnergyTo(tSide)))
-	            		|| (tTileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof IMetaTileEntityCable
-	                    		&& (((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity))
-	                    				|| ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyIn(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity))
-	                    				|| ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyOut(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity))))
-	            		|| (tTileEntity instanceof IEnergySink && ((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide)))
-	            		|| (GregTech_API.mOutputRF && tTileEntity instanceof IEnergyReceiver && ((IEnergyReceiver) tTileEntity).canConnectEnergy(ForgeDirection.getOrientation(tSide)))
-	            		/*|| (tTileEntity instanceof IEnergyEmitter && ((IEnergyEmitter)tTileEntity).emitsEnergyTo((TileEntity)getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide)))*/) {
-	                rConnect = 1;
-	            }
-	        }
-		}
+		GT_CoverBehavior coverBehavior = getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide);
+		int coverId = getBaseMetaTileEntity().getCoverIDAtSide(aSide), coverData = getBaseMetaTileEntity().getCoverDataAtSide(aSide);
+		
+		boolean sAlwaysLookConnected = coverBehavior.alwaysLookConnected(aSide, coverId, coverData, getBaseMetaTileEntity());
+		boolean sLetEnergyIn = coverBehavior.letsEnergyIn(aSide, coverId, coverData, getBaseMetaTileEntity());
+		boolean sLetEnergyOut = coverBehavior.letsEnergyOut(aSide, coverId, coverData, getBaseMetaTileEntity()); 
+		
+        if (sAlwaysLookConnected || sLetEnergyIn || sLetEnergyOut) {
+            if (tTileEntity instanceof IColoredTileEntity) {
+                if (getBaseMetaTileEntity().getColorization() >= 0) {
+                    byte tColor = ((IColoredTileEntity) tTileEntity).getColorization();
+                    if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization()) {
+                    	return rConnect;
+                    }
+                }
+            }
+            
+            boolean sHasSolarPanel = coverBehavior instanceof GT_Cover_SolarPanel;
+            
+            boolean tEnergyIsConnected = tTileEntity instanceof IEnergyConnected;
+            boolean tEnergyInOrOut = (tEnergyIsConnected && (((IEnergyConnected) tTileEntity).inputEnergyFrom(tSide) || ((IEnergyConnected) tTileEntity).outputsEnergyTo(tSide)));
+            
+            boolean tIsTileEntity = tTileEntity instanceof IGregTechTileEntity;
+            boolean tIsTileEntityCable = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof IMetaTileEntityCable; 
+            boolean tAlwaysLookConnected = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
+            boolean tLetEnergyIn = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyIn(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
+            boolean tLetEnergyOut = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyOut(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
+
+            boolean tIsEnergySink = tTileEntity instanceof IEnergySink;
+            boolean tSinkAcceptsEnergyFromSide = tIsEnergySink && ((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide));
+
+            boolean tIsEnergyReceiver = tTileEntity instanceof IEnergyReceiver;
+            boolean tEnergyReceiverCanAcceptFromSide = tIsEnergyReceiver && ((IEnergyReceiver) tTileEntity).canConnectEnergy(ForgeDirection.getOrientation(tSide));
+
+            if (   (tEnergyIsConnected && tEnergyInOrOut)
+                || sHasSolarPanel
+                || ((tIsTileEntity && tIsTileEntityCable) && (tAlwaysLookConnected || tLetEnergyIn || tLetEnergyOut) )
+                || (tIsEnergySink && tSinkAcceptsEnergyFromSide)
+                || (GregTech_API.mOutputRF && tIsEnergyReceiver && tEnergyReceiverCanAcceptFromSide)
+            		/*|| (tTileEntity instanceof IEnergyEmitter && ((IEnergyEmitter)tTileEntity).emitsEnergyTo((TileEntity)getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide)))*/) 
+            {
+                rConnect = 1;
+            }
+
+            if(D1 && rConnect == 0) {
+            	GT_Log.out.println("Gt6StyleCable - Debug: ");
+            	GT_Log.out.println("\t AlwaysLookConnected:" + sAlwaysLookConnected + " LetEnergyIn:" + sLetEnergyIn + " LetEnergyOut:" + sLetEnergyOut);
+            	GT_Log.out.println("\t sHasSolarPanel:" + sHasSolarPanel);
+            	GT_Log.out.println("\t tEnergyConnected:" + tEnergyIsConnected + " tEnergyInOrOut:" +tEnergyInOrOut);
+            	GT_Log.out.println("\t tIsTileEntity:" + tIsTileEntity + " tIsTileEntityCable:" + tIsTileEntityCable);
+            	GT_Log.out.println("\t tIsEnergySink:" + tIsEnergySink + " tSinkAcceptsEnergyFromSide:" + tSinkAcceptsEnergyFromSide );
+            	GT_Log.out.println("\t tIsEnergyReceiver:" + tIsEnergyReceiver + " tEnergyReceiverCanAcceptFromSide:" + tEnergyReceiverCanAcceptFromSide );
+            }
+
+        }
 		if (rConnect == 0) {
 			if (!getBaseMetaTileEntity().getWorld().getChunkProvider().chunkExists(getBaseMetaTileEntity().getOffsetX(aSide, 1) >> 4, getBaseMetaTileEntity().getOffsetZ(aSide, 1) >> 4)) { // if chunk unloaded
 				rConnect = -1;

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -23,7 +23,9 @@ import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Client;
 import gregtech.common.covers.GT_Cover_SolarPanel;
+import gregtech.loaders.postload.PartP2PGTPower;
 import ic2.api.energy.tile.IEnergySink;
+import ic2.api.energy.tile.IEnergySource;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -38,6 +40,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import appeng.api.parts.IPartHost;
 
 import static gregtech.api.enums.GT_Values.VN;
 
@@ -294,25 +298,30 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
             
             boolean sHasSolarPanel = coverBehavior instanceof GT_Cover_SolarPanel;
             
-            boolean tEnergyIsConnected = tTileEntity instanceof IEnergyConnected;
-            boolean tEnergyInOrOut = (tEnergyIsConnected && (((IEnergyConnected) tTileEntity).inputEnergyFrom(tSide) || ((IEnergyConnected) tTileEntity).outputsEnergyTo(tSide)));
+            boolean tIsEnergyIsConnected = tTileEntity instanceof IEnergyConnected;
+            boolean tEnergyInOrOut = (tIsEnergyIsConnected && (((IEnergyConnected) tTileEntity).inputEnergyFrom(tSide) || ((IEnergyConnected) tTileEntity).outputsEnergyTo(tSide)));
             
-            boolean tIsTileEntity = tTileEntity instanceof IGregTechTileEntity;
-            boolean tIsTileEntityCable = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof IMetaTileEntityCable; 
-            boolean tAlwaysLookConnected = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
-            boolean tLetEnergyIn = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyIn(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
-            boolean tLetEnergyOut = tIsTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyOut(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
+            boolean tIsGregTechTileEntity = tTileEntity instanceof IGregTechTileEntity;
+            boolean tIsTileEntityCable = tIsGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof IMetaTileEntityCable; 
+            boolean tAlwaysLookConnected = tIsGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
+            boolean tLetEnergyIn = tIsGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyIn(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
+            boolean tLetEnergyOut = tIsGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(tSide).letsEnergyOut(tSide, ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(tSide), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(tSide), ((IGregTechTileEntity) tTileEntity));
 
             boolean tIsEnergySink = tTileEntity instanceof IEnergySink;
             boolean tSinkAcceptsEnergyFromSide = tIsEnergySink && ((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide));
 
+            boolean tIsGTp2pProvider = (GT_Mod.gregtechproxy.mAE2Integration && tTileEntity instanceof IEnergySource 
+            		&& tTileEntity instanceof IPartHost && ((IPartHost)tTileEntity).getPart(ForgeDirection.getOrientation(tSide)) instanceof PartP2PGTPower);
+            boolean tGTp2pProvidesEnergyToSide = tIsGTp2pProvider && ((IEnergySource) tTileEntity).emitsEnergyTo((TileEntity) getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide));
+
             boolean tIsEnergyReceiver = tTileEntity instanceof IEnergyReceiver;
             boolean tEnergyReceiverCanAcceptFromSide = tIsEnergyReceiver && ((IEnergyReceiver) tTileEntity).canConnectEnergy(ForgeDirection.getOrientation(tSide));
 
-            if (   (tEnergyIsConnected && tEnergyInOrOut)
+            if (   (tIsEnergyIsConnected && tEnergyInOrOut)
                 || sHasSolarPanel
-                || ((tIsTileEntity && tIsTileEntityCable) && (tAlwaysLookConnected || tLetEnergyIn || tLetEnergyOut) )
+                || ((tIsGregTechTileEntity && tIsTileEntityCable) && (tAlwaysLookConnected || tLetEnergyIn || tLetEnergyOut) )
                 || (tIsEnergySink && tSinkAcceptsEnergyFromSide)
+                || (tIsGTp2pProvider && tGTp2pProvidesEnergyToSide)
                 || (GregTech_API.mOutputRF && tIsEnergyReceiver && tEnergyReceiverCanAcceptFromSide)
             		/*|| (tTileEntity instanceof IEnergyEmitter && ((IEnergyEmitter)tTileEntity).emitsEnergyTo((TileEntity)getBaseMetaTileEntity(), ForgeDirection.getOrientation(tSide)))*/) 
             {
@@ -323,9 +332,10 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
             	GT_Log.out.println("Gt6StyleCable - Debug: ");
             	GT_Log.out.println("\t AlwaysLookConnected:" + sAlwaysLookConnected + " LetEnergyIn:" + sLetEnergyIn + " LetEnergyOut:" + sLetEnergyOut);
             	GT_Log.out.println("\t sHasSolarPanel:" + sHasSolarPanel);
-            	GT_Log.out.println("\t tEnergyConnected:" + tEnergyIsConnected + " tEnergyInOrOut:" +tEnergyInOrOut);
-            	GT_Log.out.println("\t tIsTileEntity:" + tIsTileEntity + " tIsTileEntityCable:" + tIsTileEntityCable);
+            	GT_Log.out.println("\t tIsEnergyIsConnected:" + tIsEnergyIsConnected + " tEnergyInOrOut:" +tEnergyInOrOut);
+            	GT_Log.out.println("\t tIsGregTechTileEntity:" + tIsGregTechTileEntity + " tIsTileEntityCable:" + tIsTileEntityCable);
             	GT_Log.out.println("\t tIsEnergySink:" + tIsEnergySink + " tSinkAcceptsEnergyFromSide:" + tSinkAcceptsEnergyFromSide );
+            	GT_Log.out.println("\t tIsGTp2pProvider:" + tIsGTp2pProvider + " tGTp2pProvidesEnergyToSide:" + tGTp2pProvidesEnergyToSide );
             	GT_Log.out.println("\t tIsEnergyReceiver:" + tIsEnergyReceiver + " tEnergyReceiverCanAcceptFromSide:" + tEnergyReceiverCanAcceptFromSide );
             }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -241,7 +241,6 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
     	return onConnectionToolRightClick(aSide, aWrenchingSide, aPlayer, aX, aY, aZ);
     }
 
-    @Override
     public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
     	return onConnectionToolRightClick(aSide, aWrenchingSide, aPlayer, aX, aY, aZ);
     }

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -238,23 +238,27 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
     @Override
     public boolean onWireCutterRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-    	return onConnectionToolRightClick(aSide, aWrenchingSide, aPlayer, aX, aY, aZ);
-    }
-
-    public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-    	return onConnectionToolRightClick(aSide, aWrenchingSide, aPlayer, aX, aY, aZ);
-    }
-
-    private boolean onConnectionToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
-    	if (GT_Mod.gregtechproxy.gt6Cable) {
-    		if (!isConnectedAtSide(aWrenchingSide)) {
-    			if (GT_Mod.gregtechproxy.costlyCableConnection && !GT_ModHandler.consumeSolderingMaterial(aPlayer)) return false;
+        if (GT_Mod.gregtechproxy.gt6Cable && GT_ModHandler.damageOrDechargeItem(aPlayer.inventory.getCurrentItem(), 1, 500, aPlayer)) {
+            if(isConnectedAtSide(aWrenchingSide)) {
+                disconnect(aWrenchingSide);
+                GT_Utility.sendChatToPlayer(aPlayer, trans("215", "Disconnected"));
+            }else if(!GT_Mod.gregtechproxy.costlyCableConnection){
     			if (connect(aWrenchingSide) > 0)
     				GT_Utility.sendChatToPlayer(aPlayer, trans("214", "Connected"));
     		}
-    		else {
+            return true;
+        }
+        return false;
+    }
+
+    public boolean onSolderingToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        if (GT_Mod.gregtechproxy.gt6Cable && GT_ModHandler.damageOrDechargeItem(aPlayer.inventory.getCurrentItem(), 1, 500, aPlayer)) {
+            if (isConnectedAtSide(aWrenchingSide)) {
     			disconnect(aWrenchingSide);
     			GT_Utility.sendChatToPlayer(aPlayer, trans("215", "Disconnected"));
+            } else if (!GT_Mod.gregtechproxy.costlyCableConnection || GT_ModHandler.consumeSolderingMaterial(aPlayer)) {
+                if (connect(aWrenchingSide) > 0)
+                    GT_Utility.sendChatToPlayer(aPlayer, trans("214", "Connected"));
     		}
     		return true;
     	}

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -248,14 +248,13 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
     private boolean onConnectionToolRightClick(byte aSide, byte aWrenchingSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
     	if (GT_Mod.gregtechproxy.gt6Cable) {
-    		byte tSide = GT_Utility.determineWrenchingSide(aSide, aX, aY, aZ);
-    		if (!isConnectedAtSide(tSide)) {
+    		if (!isConnectedAtSide(aWrenchingSide)) {
     			if (GT_Mod.gregtechproxy.costlyCableConnection && !GT_ModHandler.consumeSolderingMaterial(aPlayer)) return false;
-    			if (connect(tSide) > 0)
+    			if (connect(aWrenchingSide) > 0)
     				GT_Utility.sendChatToPlayer(aPlayer, trans("214", "Connected"));
     		}
     		else {
-    			disconnect(tSide);
+    			disconnect(aWrenchingSide);
     			GT_Utility.sendChatToPlayer(aPlayer, trans("215", "Disconnected"));
     		}
     		return true;

--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -422,15 +422,15 @@ public class GT_Client extends GT_Proxy
             TileEntity aTileEntity = aEvent.player.worldObj.getTileEntity(aEvent.target.blockX, aEvent.target.blockY, aEvent.target.blockZ);
             try {
                 Class.forName("codechicken.lib.vec.Rotation");
-                if (((aTileEntity instanceof BaseMetaPipeEntity)) && (((ICoverable) aTileEntity).getCoverIDAtSide((byte) aEvent.target.sideHit) == 0) && ((GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sCovers.keySet())) || (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sCrowbarList)) || (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sScrewdriverList)) || (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sWireCutterList)) || (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sSolderingToolList)))) {
+                if (((aTileEntity instanceof BaseMetaPipeEntity)) && (((ICoverable) aTileEntity).getCoverIDAtSide((byte) aEvent.target.sideHit) == 0) && ((GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sCovers.keySet())) || (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sCrowbarList)) || (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sWireCutterList)) || (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sScrewdriverList))|| GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sSolderingToolList))) {
                     drawGrid(aEvent);
                     return;
                 }
-                if ((((aTileEntity instanceof ITurnable)) || (ROTATABLE_VANILLA_BLOCKS.contains(aBlock)) || ((aTileEntity instanceof IWrenchable))) && (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sWrenchList))) {
+                if ((aTileEntity instanceof ITurnable || ROTATABLE_VANILLA_BLOCKS.contains(aBlock) || aTileEntity instanceof IWrenchable) && GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sWrenchList)) {
                     drawGrid(aEvent);
                     return;
                 }
-                if (aTileEntity instanceof BaseTileEntity && (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sWireCutterList))) {
+                if (aTileEntity instanceof BaseTileEntity && (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sWireCutterList) || GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sSolderingToolList))) {
                 	drawGrid(aEvent);
                 	return;
             	}

--- a/src/main/java/gregtech/common/GT_Client.java
+++ b/src/main/java/gregtech/common/GT_Client.java
@@ -16,6 +16,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.ITurnable;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
+import gregtech.api.metatileentity.BaseTileEntity;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_PlayedSound;
@@ -429,6 +430,10 @@ public class GT_Client extends GT_Proxy
                     drawGrid(aEvent);
                     return;
                 }
+                if (aTileEntity instanceof BaseTileEntity && (GT_Utility.isStackInList(aEvent.currentItem, GregTech_API.sWireCutterList))) {
+                	drawGrid(aEvent);
+                	return;
+            	}
             } catch (Throwable e) {
                 if (GT_Values.D1) {
                     e.printStackTrace(GT_Log.err);

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -290,7 +290,7 @@ public class GT_Block_Machines
         if(aPlayer.isSneaking()){
         	ItemStack tCurrentItem = aPlayer.inventory.getCurrentItem();
         	if(tCurrentItem!=null){
-        		if(!GT_Utility.isStackInList(tCurrentItem, GregTech_API.sScrewdriverList) && !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWrenchList)){
+        		if(!GT_Utility.isStackInList(tCurrentItem, GregTech_API.sScrewdriverList) && !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWrenchList) && !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sWireCutterList) && !GT_Utility.isStackInList(tCurrentItem, GregTech_API.sSolderingToolList)){
         			return false;
         		}
         	}else {return false;}

--- a/src/main/java/gregtech/common/covers/GT_Cover_SolarPanel.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_SolarPanel.java
@@ -26,6 +26,10 @@ public class GT_Cover_SolarPanel
         return aCoverVariable;
     }
 
+    public boolean alwaysLookConnected(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+    	return true;
+    }
+
     public int getTickRate(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
         return 1;
     }


### PR DESCRIPTION
Allow use of wire cutter/soldering item on the tile entity, as well as the wire, for a connect/disconnect. Useful for when the cable you want to power the machine is hidden behind the machine and not easily accessible.

Porting upstream from https://github.com/GTNewHorizons/GT5-Unofficial/pull/64