### PR TITLE
Fix that the main facing of basic machines can be set to top/bottom

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine.java
@@ -109,11 +109,16 @@ public abstract class GT_MetaTileEntity_BasicMachine extends GT_MetaTileEntity_B
         mGUIName = aGUIName;
         mNEIName = aNEIName;
     }
+
+    protected boolean isValidMainFacing(byte aSide) {
+    	return aSide > 1;
+    }
     
-    public boolean setMainFacing(byte aDirection){
-    	mMainFacing = aDirection;
+    public boolean setMainFacing(byte aSide){
+    	if (!isValidMainFacing(aSide)) return false;
+    	mMainFacing = aSide;
     	if(getBaseMetaTileEntity().getFrontFacing() == mMainFacing){
-    		getBaseMetaTileEntity().setFrontFacing(GT_Utility.getOppositeSide(aDirection));
+    		getBaseMetaTileEntity().setFrontFacing(GT_Utility.getOppositeSide(aSide));
     	}
         onFacingChange();
         onMachineBlockUpdate();


### PR DESCRIPTION
In fact, the main facing(or intuitively, the front side) will always be set to the front facing(which is actually the output side) when you try to set it to the top/bottom side.