### PR TITLE
NEI support enhancement

### DIFF
--- a/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
+++ b/src/main/java/gregtech/api/util/GT_OreDictUnificator.java
@@ -15,6 +15,7 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -32,6 +33,7 @@ import static gregtech.api.enums.GT_Values.*;
 public class GT_OreDictUnificator {
     private static final /*ConcurrentHash*/Map<String, ItemStack> sName2StackMap = new /*ConcurrentHash*/HashMap<String, ItemStack>();
     private static final /*ConcurrentHash*/Map<GT_ItemStack, ItemData> sItemStack2DataMap = new /*ConcurrentHash*/HashMap<GT_ItemStack, ItemData>();
+    private static final /*ConcurrentHash*/Map<GT_ItemStack, List<ItemStack>> sUnificationTable = new /*ConcurrentHash*/HashMap<GT_ItemStack, List<ItemStack>>();
     private static final GT_HashSet<GT_ItemStack> sNoUnificationList = new GT_HashSet<GT_ItemStack>();
     public static volatile int VERSION = 509;
     private static int isRegisteringOre = 0, isAddingOre = 0;
@@ -39,6 +41,7 @@ public class GT_OreDictUnificator {
 
     static {
         GregTech_API.sItemStackMappings.add(sItemStack2DataMap);
+        GregTech_API.sItemStackMappings.add(sUnificationTable);
     }
 
     /**
@@ -144,13 +147,49 @@ public class GT_OreDictUnificator {
             tPrefixMaterial.mBlackListed = true;
             return GT_Utility.copy(aStack);
         }
-        if (tPrefixMaterial.mUnificationTarget == null)
-            tPrefixMaterial.mUnificationTarget = sName2StackMap.get(tPrefixMaterial.toString());
+        if (tPrefixMaterial.mUnificationTarget == null) {
+        	tPrefixMaterial.mUnificationTarget = sName2StackMap.get(tPrefixMaterial.toString());
+        	sUnificationTable.clear();
+        }
         rStack = tPrefixMaterial.mUnificationTarget;
         if (GT_Utility.isStackInvalid(rStack)) return GT_Utility.copy(aStack);
         assert rStack != null;
         rStack.setTagCompound(aStack.getTagCompound());
         return GT_Utility.copyAmount(aStack.stackSize, rStack);
+    }
+
+    public static List<ItemStack> getNonUnifiedStacks(Object obj) {
+    	synchronized (sUnificationTable) {
+    		if (sUnificationTable.isEmpty() && !sItemStack2DataMap.isEmpty()) {
+            	for (GT_ItemStack tGTStack0 : sItemStack2DataMap.keySet()) {
+            		ItemStack tStack0 = tGTStack0.toStack();
+            		ItemStack tStack1 = get(false, tStack0);
+            		if (!GT_Utility.areStacksEqual(tStack0, tStack1)) {
+            			GT_ItemStack tGTStack1 = new GT_ItemStack(tStack1);
+            			List<ItemStack> list = sUnificationTable.get(tGTStack1);
+            			if (list == null) sUnificationTable.put(tGTStack1, list = new ArrayList<ItemStack>());
+            			if (!list.contains(tStack0)) list.add(tStack0);
+            		}
+            	}
+        	}
+    	}
+    	ItemStack[] aStacks = {};
+    	if (obj instanceof ItemStack) aStacks = new ItemStack[]{(ItemStack) obj};
+    	else if (obj instanceof ItemStack[]) aStacks = (ItemStack[]) obj;
+    	else if (obj instanceof List) aStacks = (ItemStack[]) ((List)obj).toArray(new ItemStack[0]);
+    	List<ItemStack> rList = new ArrayList<ItemStack>();
+    	for (ItemStack aStack : aStacks) {
+    		rList.add(aStack);
+    		List<ItemStack> tList = sUnificationTable.get(new GT_ItemStack(aStack));
+    		if (tList != null) {
+    			for (ItemStack tStack : tList) {
+            		ItemStack tStack1 = GT_Utility.copyAmount(aStack.stackSize, tStack);
+            		tStack1.setTagCompound(aStack.getTagCompound());
+            		rList.add(tStack1);
+            	}
+    		}
+    	}
+    	return rList;
     }
 
     public static void addItemData(ItemStack aStack, ItemData aData) {
@@ -250,6 +289,7 @@ public class GT_OreDictUnificator {
 
     public static void resetUnificationEntries() {
         for (ItemData tPrefixMaterial : sItemStack2DataMap.values()) tPrefixMaterial.mUnificationTarget = null;
+        sUnificationTable.clear();
     }
 
     public static ItemStack getGem(MaterialStack aMaterial) {

--- a/src/main/java/gregtech/common/gui/GT_GUIContainer_PrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/gui/GT_GUIContainer_PrimitiveBlastFurnace.java
@@ -6,11 +6,13 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 public class GT_GUIContainer_PrimitiveBlastFurnace extends GT_GUIContainerMetaTile_Machine {
 	private String name;
+	public String mNEI;
 	
-	public GT_GUIContainer_PrimitiveBlastFurnace(InventoryPlayer inventoryPlayer, IGregTechTileEntity tileEntity, String name) {
+	public GT_GUIContainer_PrimitiveBlastFurnace(InventoryPlayer inventoryPlayer, IGregTechTileEntity tileEntity, String name, String aNEI) {
 		super(new GT_Container_PrimitiveBlastFurnace(inventoryPlayer, tileEntity), 
 				String.format("gregtech:textures/gui/%s.png", name.replace(" ", "")));
 		this.name = name;
+		this.mNEI = aNEI;
 	}
 
 	protected void drawGuiContainerForegroundLayer(int par1, int par2) {

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_PrimitiveBlastFurnace.java
@@ -139,7 +139,7 @@ public abstract class GT_MetaTileEntity_PrimitiveBlastFurnace extends MetaTileEn
 	}
 
 	public Object getClientGUI(int aID, InventoryPlayer aPlayerInventory, IGregTechTileEntity aBaseMetaTileEntity) {
-		return new GT_GUIContainer_PrimitiveBlastFurnace(aPlayerInventory, aBaseMetaTileEntity, getName());
+		return new GT_GUIContainer_PrimitiveBlastFurnace(aPlayerInventory, aBaseMetaTileEntity, getName(), GT_Recipe.GT_Recipe_Map.sPrimitiveBlastRecipes.mNEIName);
 	}
 
 	private boolean checkMachine() {

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -20,6 +20,7 @@ import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Recipe;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.gui.GT_GUIContainer_FusionReactor;
+import gregtech.common.gui.GT_GUIContainer_PrimitiveBlastFurnace;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.init.Blocks;
@@ -258,7 +259,9 @@ public class GT_NEI_DefaultHandler
         }
 
         public boolean canHandle(GuiContainer gui) {
-            return (((gui instanceof GT_GUIContainer_BasicMachine)) && (GT_Utility.isStringValid(((GT_GUIContainer_BasicMachine) gui).mNEI)) || ((gui instanceof GT_GUIContainer_FusionReactor)) && (GT_Utility.isStringValid(((GT_GUIContainer_FusionReactor) gui).mNEI)));
+            return (gui instanceof GT_GUIContainer_BasicMachine && GT_Utility.isStringValid(((GT_GUIContainer_BasicMachine) gui).mNEI))
+            		|| (gui instanceof GT_GUIContainer_FusionReactor && GT_Utility.isStringValid(((GT_GUIContainer_FusionReactor) gui).mNEI))
+            		|| (gui instanceof GT_GUIContainer_PrimitiveBlastFurnace && GT_Utility.isStringValid(((GT_GUIContainer_PrimitiveBlastFurnace) gui).mNEI));
         }
 
         public List<String> handleTooltip(GuiContainer gui, int mousex, int mousey, List<String> currenttip) {
@@ -266,6 +269,8 @@ public class GT_NEI_DefaultHandler
                 if (gui instanceof GT_GUIContainer_BasicMachine && new Rectangle(65, 13, 36, 18).contains(new Point(GuiDraw.getMousePosition().x - ((GT_GUIContainer_BasicMachine) gui).getLeft() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[0], GuiDraw.getMousePosition().y - ((GT_GUIContainer_BasicMachine) gui).getTop() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[1]))) {
                     currenttip.add("Recipes");
                 } else if (gui instanceof GT_GUIContainer_FusionReactor && new Rectangle(145, 0, 24, 24).contains(new Point(GuiDraw.getMousePosition().x - ((GT_GUIContainer_FusionReactor) gui).getLeft() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[0], GuiDraw.getMousePosition().y - ((GT_GUIContainer_FusionReactor) gui).getTop() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[1]))) {
+                    currenttip.add("Recipes");
+                } else if (gui instanceof GT_GUIContainer_PrimitiveBlastFurnace && new Rectangle(51, 10, 24, 24).contains(new Point(GuiDraw.getMousePosition().x - ((GT_GUIContainer_PrimitiveBlastFurnace) gui).getLeft() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[0], GuiDraw.getMousePosition().y - ((GT_GUIContainer_PrimitiveBlastFurnace) gui).getTop() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[1]))) {
                     currenttip.add("Recipes");
                 }
 
@@ -278,6 +283,9 @@ public class GT_NEI_DefaultHandler
                 return (canHandle(gui)) && (new Rectangle(65, 13, 36, 18).contains(new Point(GuiDraw.getMousePosition().x - ((GT_GUIContainer_BasicMachine) gui).getLeft() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[0], GuiDraw.getMousePosition().y - ((GT_GUIContainer_BasicMachine) gui).getTop() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[1]))) && (usage ? GuiUsageRecipe.openRecipeGui(((GT_GUIContainer_BasicMachine) gui).mNEI, new Object[0]) : GuiCraftingRecipe.openRecipeGui(((GT_GUIContainer_BasicMachine) gui).mNEI, new Object[0]));
             } else if (gui instanceof GT_GUIContainer_FusionReactor) {
                 return (canHandle(gui)) && (new Rectangle(145, 0, 24, 24).contains(new Point(GuiDraw.getMousePosition().x - ((GT_GUIContainer_FusionReactor) gui).getLeft() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[0], GuiDraw.getMousePosition().y - ((GT_GUIContainer_FusionReactor) gui).getTop() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[1]))) && (usage ? GuiUsageRecipe.openRecipeGui(((GT_GUIContainer_FusionReactor) gui).mNEI, new Object[0]) : GuiCraftingRecipe.openRecipeGui(((GT_GUIContainer_FusionReactor) gui).mNEI, new Object[0]));
+            } else if (gui instanceof GT_GUIContainer_PrimitiveBlastFurnace) {
+            	int[] a = codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui);
+                return (canHandle(gui)) && (new Rectangle(51, 10, 24, 24).contains(new Point(GuiDraw.getMousePosition().x - ((GT_GUIContainer_PrimitiveBlastFurnace) gui).getLeft() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[0], GuiDraw.getMousePosition().y - ((GT_GUIContainer_PrimitiveBlastFurnace) gui).getTop() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[1]))) && (usage ? GuiUsageRecipe.openRecipeGui(((GT_GUIContainer_PrimitiveBlastFurnace) gui).mNEI, new Object[0]) : GuiCraftingRecipe.openRecipeGui(((GT_GUIContainer_PrimitiveBlastFurnace) gui).mNEI, new Object[0]));
             }
             return false;
         }

--- a/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
+++ b/src/main/java/gregtech/nei/GT_NEI_DefaultHandler.java
@@ -284,7 +284,6 @@ public class GT_NEI_DefaultHandler
             } else if (gui instanceof GT_GUIContainer_FusionReactor) {
                 return (canHandle(gui)) && (new Rectangle(145, 0, 24, 24).contains(new Point(GuiDraw.getMousePosition().x - ((GT_GUIContainer_FusionReactor) gui).getLeft() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[0], GuiDraw.getMousePosition().y - ((GT_GUIContainer_FusionReactor) gui).getTop() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[1]))) && (usage ? GuiUsageRecipe.openRecipeGui(((GT_GUIContainer_FusionReactor) gui).mNEI, new Object[0]) : GuiCraftingRecipe.openRecipeGui(((GT_GUIContainer_FusionReactor) gui).mNEI, new Object[0]));
             } else if (gui instanceof GT_GUIContainer_PrimitiveBlastFurnace) {
-            	int[] a = codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui);
                 return (canHandle(gui)) && (new Rectangle(51, 10, 24, 24).contains(new Point(GuiDraw.getMousePosition().x - ((GT_GUIContainer_PrimitiveBlastFurnace) gui).getLeft() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[0], GuiDraw.getMousePosition().y - ((GT_GUIContainer_PrimitiveBlastFurnace) gui).getTop() - codechicken.nei.recipe.RecipeInfo.getGuiOffset(gui)[1]))) && (usage ? GuiUsageRecipe.openRecipeGui(((GT_GUIContainer_PrimitiveBlastFurnace) gui).mNEI, new Object[0]) : GuiCraftingRecipe.openRecipeGui(((GT_GUIContainer_PrimitiveBlastFurnace) gui).mNEI, new Object[0]));
             }
             return false;
@@ -331,7 +330,7 @@ public class GT_NEI_DefaultHandler
         }
 
         public FixedPositionedStack(Object object, int x, int y, int aChance) {
-            super(object, x, y, true);
+            super(GT_OreDictUnificator.getNonUnifiedStacks(object), x, y, true);
             this.mChance = aChance;
         }
 


### PR DESCRIPTION
- NEI recipe page access of Primitive Blast Furnace
Recipes of primitive blast furnace is no longer hard-coded. Now it has its own recipe map; but we still cannot directly query its recipes from its GUI.

- Fix #1039 
[These adders](https://github.com/Blood-Asp/GT5-Unofficial/blob/unstable/src/main/java/gregtech/api/interfaces/internal/IGT_RecipeAdder.java#L284-L286) does not always work as expected: those items form the same oredict will sometimes [be unified](https://github.com/Blood-Asp/GT5-Unofficial/blob/unstable/src/main/java/gregtech/api/util/GT_Recipe.java#L355) when finding recipe to check for collision. As a result, the recipes collide, with only one of them added into recipe map, which finally shown by NEI.
  