### PR TITLE
Fix custom enchantment for materials

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -312,6 +312,10 @@ public class GT_Mod implements IGT_Mod {
                 tPrefix.mDefaultStackSize = ((byte) Math.min(64, Math.max(16, tMainConfig.get("features", "MaxOtherBlockStackSize", 64).getInt())));
             }
         }
+        
+        new Enchantment_EnderDamage();
+        new Enchantment_Radioactivity();
+        
         //GT_Config.troll = (Calendar.getInstance().get(2) + 1 == 4) && (Calendar.getInstance().get(5) >= 1) && (Calendar.getInstance().get(5) <= 2);
         Materials.init();
 
@@ -445,9 +449,6 @@ public class GT_Mod implements IGT_Mod {
         }
         }else{System.out.println("noMaterial "+reEnable);}
         }else{System.out.println("noPrefix "+reEnable);}}
-        
-        new Enchantment_EnderDamage();
-        new Enchantment_Radioactivity();
 
         new GT_Loader_OreProcessing().run();
         new GT_Loader_OreDictionary().run();


### PR DESCRIPTION
Enchantments should be initialized and registered before loading material configs, or the customization of enchantment of some materials won't work.