### PR TITLE
Fix: Fluid pipes transfer capacity

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Fluid.java
@@ -317,6 +317,8 @@ public class GT_MetaPipeEntity_Fluid extends MetaPipeEntity {
                                 tTankAmounts.set(tankIndex, (successfulTankInfo.fluid != null)
                                         ? successfulTankInfo.capacity - successfulTankInfo.fluid.amount
                                         : successfulTankInfo.capacity);
+                            } else {
+                                tTankAmounts.set(tankIndex, mCapacity * 20);
                             }
 
                             totalFreeAmount += tTankAmounts.get(tankIndex);


### PR DESCRIPTION
**Fixed:** The pipe lost its transfer capacity if one pipe block had more than one consumer.

**Added:** The fluid distribution algorithm is optimized. Now the fluid flows along the path of least resistance.
Not all GT-machines return fluid tank info. For these machines, a fluid pipe use a capacity similar to its own (considering it to be empty).

Illustrations attached:
![mc1](https://user-images.githubusercontent.com/12990676/35008107-85dca3fe-fb0c-11e7-8a30-e4395c0abfbd.png)
![mc2](https://user-images.githubusercontent.com/12990676/35008106-85b8bb60-fb0c-11e7-912c-d13b0a9b942b.png)
![mc3](https://user-images.githubusercontent.com/12990676/35008105-859679b0-fb0c-11e7-989a-a4dc5fee3f12.png)
![mc4](https://user-images.githubusercontent.com/12990676/35008104-85723668-fb0c-11e7-823f-f19087ef10ad.png)
![mc5](https://user-images.githubusercontent.com/12990676/35008103-854b3c66-fb0c-11e7-959e-b6da350c47ce.png)
