### PR TITLE
Fix: GregTech axe don't harvest blocks that have no harvest tool

### DIFF
--- a/src/main/java/gregtech/common/tools/GT_Tool_Axe.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_Axe.java
@@ -81,7 +81,7 @@ public class GT_Tool_Axe
 
     public boolean isMinableBlock(Block aBlock, byte aMetaData) {
         String tTool = aBlock.getHarvestTool(aMetaData);
-        return ((tTool != null) && (tTool.equals("axe"))) || (aBlock.getMaterial() == Material.wood);
+        return tTool == null || tTool.equals("axe") || (aBlock.getMaterial() == Material.wood);
     }
 
     public int convertBlockDrops(List<ItemStack> aDrops, ItemStack aStack, EntityPlayer aPlayer, Block aBlock, int aX, int aY, int aZ, byte aMetaData, int aFortune, boolean aSilkTouch, BlockEvent.HarvestDropsEvent aEvent) {


### PR DESCRIPTION
Issue: #555 

**Documentation say's:** If block have no harvest tool (harvest tool is null), then this block can be harvested with any tool.

GregTech axe did not obey this rule. Now GT axe can harvest vines, crops and etc.