### PR TITLE
Fix the random maintenance issue of Fusion Reactor

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_FusionComputer.java
@@ -386,6 +386,15 @@ public abstract class GT_MetaTileEntity_FusionComputer extends GT_MetaTileEntity
     }
 
     @Override
+    public boolean doRandomMaintenanceDamage() {
+    	if (!isCorrectMachinePart(mInventory[1]) || getRepairStatus() == 0) {
+            stopMachine();
+            return false;
+        }
+    	return true;
+    }
+
+    @Override
     public boolean onRunningTick(ItemStack aStack) {
         if (mEUt < 0) {
             if (!drainEnergyInput(((long) -mEUt * 10000) / Math.max(1000, mEfficiency))) {


### PR DESCRIPTION
Fusion Reactors don't have a maintenance hatch, so it shouldn't occur such maintenance issue either.