### PR TITLE
Fixed bug in fluid filter behavior.

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -1181,11 +1181,11 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
             return false;
 
         if(isFill && mMetaTileEntity.isLiquidInput((byte) aSide.ordinal())
-                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), mMetaTileEntity.getFluid() == null ? null : mMetaTileEntity.getFluid().getFluid(), this))
+                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidIn((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), aFluid, this))
             return true;
 
         if (!isFill && mMetaTileEntity.isLiquidOutput((byte) aSide.ordinal()) 
-                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), mMetaTileEntity.getFluid() == null ? null : mMetaTileEntity.getFluid().getFluid(), this))
+                && getCoverBehaviorAtSide((byte) aSide.ordinal()).letsFluidOut((byte) aSide.ordinal(), getCoverIDAtSide((byte) aSide.ordinal()), getCoverDataAtSide((byte) aSide.ordinal()), aFluid, this))
             return true;
 
     	return false;

--- a/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
@@ -64,13 +64,13 @@ public class GT_Cover_Fluidfilter
         if(aFluid==null){return true;}
         int aFilterMode = aCoverVariable & 7;
         int aFilterFluid = aCoverVariable >>> 3;
-        return aFluid.getID() == aFilterFluid ? (aFilterMode == 0 || aFilterMode == 2 ? true : false) : (aFilterMode == 1 || aFilterMode == 3 ? true : false);
+        return aFluid.getID() == aFilterFluid ? aFilterMode == 0 || aFilterMode == 2 : aFilterMode == 1 || aFilterMode == 3;
     }
     
     @Override
     public boolean letsFluidOut(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
         int aFilterMode = aCoverVariable & 7;
-        return  aFilterMode == 0 || aFilterMode == 1 ? false : true;
+        return aFilterMode != 0 && aFilterMode != 1;
     }
     
     public boolean alwaysLookConnected(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {


### PR DESCRIPTION
Fluid filter don't work at all.
Steps to reproduce - just try to filter any liquid.
Thats happened because method canMoveFluidOnSide check internal tank liquid instead of given liquid (line 1184 & 1188).
Also simplified few ridiculous expression (like (bool) ? false : true).