### PR TITLE
Fixed bug - drain cover don't work when installed on pipe.

### DIFF
--- a/src/main/java/gregtech/common/covers/GT_Cover_Drain.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Drain.java
@@ -43,8 +43,8 @@ public class GT_Cover_Drain
                         tLiquid = ((IFluidBlock) tBlock).drain(aTileEntity.getWorld(), aTileEntity.getOffsetX(aSide, 1), aTileEntity.getOffsetY(aSide, 1), aTileEntity.getOffsetZ(aSide, 1), false);
                     }
                     if ((tLiquid != null) && (tLiquid.getFluid() != null) && ((aSide > 1) || ((aSide == 0) && (tLiquid.getFluid().getDensity() <= 0)) || ((aSide == 1) && (tLiquid.getFluid().getDensity() >= 0))) &&
-                            (((IFluidHandler) aTileEntity).fill(ForgeDirection.getOrientation(aSide), tLiquid, false) == tLiquid.amount)) {
-                        ((IFluidHandler) aTileEntity).fill(ForgeDirection.getOrientation(aSide), tLiquid, true);
+                            (((IFluidHandler) aTileEntity).fill(ForgeDirection.UNKNOWN, tLiquid, false) == tLiquid.amount)) {
+                        ((IFluidHandler) aTileEntity).fill(ForgeDirection.UNKNOWN, tLiquid, true);
                         aTileEntity.getWorld().setBlockToAir(aTileEntity.getXCoord() + ForgeDirection.getOrientation(aSide).offsetX, aTileEntity.getYCoord() + ForgeDirection.getOrientation(aSide).offsetY, aTileEntity.getZCoord() + ForgeDirection.getOrientation(aSide).offsetZ);
                     }
                 }


### PR DESCRIPTION
Drain cover insert liquid into pipe from side where it installed, but because pipe not connected to nothing else from this side it forbidden liquid transfer.
This fix resolve this bug, but may have some side effects when drain installed on machine (but i think nothing critical).