### PR TITLE
Fixed bug - Axe harvest stone blocks from Underground Biomes Construct

### DIFF
--- a/src/main/java/gregtech/common/tools/GT_Tool_Axe.java
+++ b/src/main/java/gregtech/common/tools/GT_Tool_Axe.java
@@ -81,7 +81,7 @@ public class GT_Tool_Axe
 
     public boolean isMinableBlock(Block aBlock, byte aMetaData) {
         String tTool = aBlock.getHarvestTool(aMetaData);
-        return tTool == null || tTool.equals("axe") || (aBlock.getMaterial() == Material.wood);
+        return ((tTool == null) && aBlock.getMaterial().isToolNotRequired()) || (tTool != null && tTool.equals("axe")) || (aBlock.getMaterial() == Material.wood);
     }
 
     public int convertBlockDrops(List<ItemStack> aDrops, ItemStack aStack, EntityPlayer aPlayer, Block aBlock, int aX, int aY, int aZ, byte aMetaData, int aFortune, boolean aSilkTouch, BlockEvent.HarvestDropsEvent aEvent) {


### PR DESCRIPTION
After fix #1382 axes from GT5 could harvest stone and cobblestone blocks from Underground Biomes Construct. Their harvest tool equal to null.
This fix resolve this bug.