### PR TITLE
Pipe/cable overhaul;  Fluidfilter fix, GC Energy Compat & Misc fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,12 +101,12 @@ repositories {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
+//    compile fileTree(dir: 'libs', include: '*.jar')
 
     compile "tconstruct:TConstruct:${config.minecraft.version}-${config.tconstruct.version}:deobf"
-//    provided ("appeng:appliedenergistics2:${config.ae2.version}:dev") {
-//        exclude module: '*'
-//    }
+    provided ("appeng:appliedenergistics2:${config.ae2.version}:dev") {
+        exclude module: '*'
+    }
     provided "codechicken:CodeChickenLib:${config.minecraft.version}-${config.codechickenlib.version}:dev"
 	provided "codechicken:CodeChickenCore:${config.minecraft.version}-${config.codechickencore.version}:dev"
     provided "codechicken:NotEnoughItems:${config.minecraft.version}-${config.nei.version}:dev"
@@ -119,12 +119,16 @@ dependencies {
         transitive = false
     }
     provided name: 'buildcraft', version: config.buildcraft.version, classifier: "dev", ext: 'jar'
-//    provided name: 'CoFHLib', version: config.cofhlib.version, ext: 'jar'
-//    provided name: 'CoFHCore', version: config.cofhcore.version, ext: 'jar'
-//    provided name: 'Railcraft', version: config.railcraft.version, ext: 'jar'
-//    provided name: 'IC2NuclearControl', version: config.nc.version, ext: 'jar'
-//    provided name: 'ImmersiveEngineering', version: config.immeng.version, ext: 'jar'
-
+    provided name: 'CoFHLib', version: config.cofhlib.version, ext: 'jar'
+    provided name: 'CoFHCore', version: config.cofhcore.version, ext: 'jar'
+    provided name: 'Railcraft', version: config.railcraft.version, ext: 'jar'
+    provided name: 'IC2NuclearControl', version: config.nc.version, ext: 'jar'
+    provided name: 'ImmersiveEngineering', version: config.immeng.version, ext: 'jar'
+    provided name: 'magneticraft', version: config.magneticraft.version, ext: 'jar'
+//    compile files("libs/Galacticraft-API-1.7-${config.gc.version}.jar")
+//    compile files("libs/GalacticraftCore-Dev-${config.gc.version}.jar")
+    provided name: "Galacticraft-API", version: config.gc.version, ext: 'jar'
+    provided name: "GalacticraftCore-Dev", version: config.gc.version, ext: 'jar'
 }
 
 processResources

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,11 @@ repositories {
         name 'tterrag Repo'
         url "http://maven.tterrag.com"
     }
+    maven { // TConstruct
+        name 'DVS1 Maven FS'
+        url 'http://dvs1.progwml6.com/files/maven'
+    }
+
     maven { // AppleCore
         url "http://www.ryanliptak.com/maven/"
     }
@@ -96,12 +101,16 @@ repositories {
 }
 
 dependencies {
-    provided ("appeng:appliedenergistics2:${config.ae2.version}:dev") {
-        exclude module: '*'
-    }
+    compile fileTree(dir: 'libs', include: '*.jar')
+
+    compile "tconstruct:TConstruct:${config.minecraft.version}-${config.tconstruct.version}:deobf"
+//    provided ("appeng:appliedenergistics2:${config.ae2.version}:dev") {
+//        exclude module: '*'
+//    }
     provided "codechicken:CodeChickenLib:${config.minecraft.version}-${config.codechickenlib.version}:dev"
 	provided "codechicken:CodeChickenCore:${config.minecraft.version}-${config.codechickencore.version}:dev"
     provided "codechicken:NotEnoughItems:${config.minecraft.version}-${config.nei.version}:dev"
+    provided "codechicken:Translocator:${config.minecraft.version}-${config.translocators.version}:dev"
     provided "net.industrial-craft:industrialcraft-2:${config.ic2.version}:dev"
     provided "net.sengir.forestry:forestry_${config.minecraft.version}:${config.forestry.version}:dev"
     provided "applecore:AppleCore:${config.applecore.version}:api"
@@ -110,12 +119,12 @@ dependencies {
         transitive = false
     }
     provided name: 'buildcraft', version: config.buildcraft.version, classifier: "dev", ext: 'jar'
-    provided name: 'CoFHLib', version: config.cofhlib.version, ext: 'jar'
-    provided name: 'CoFHCore', version: config.cofhcore.version, ext: 'jar'
-    provided name: 'Railcraft', version: config.railcraft.version, ext: 'jar'
-    provided name: 'IC2NuclearControl', version: config.nc.version, ext: 'jar'
-    provided name: 'ImmersiveEngineering', version: config.immeng.version, ext: 'jar'
-    provided name: 'magneticraft', version: config.magneticraft.version, ext: 'jar'
+//    provided name: 'CoFHLib', version: config.cofhlib.version, ext: 'jar'
+//    provided name: 'CoFHCore', version: config.cofhcore.version, ext: 'jar'
+//    provided name: 'Railcraft', version: config.railcraft.version, ext: 'jar'
+//    provided name: 'IC2NuclearControl', version: config.nc.version, ext: 'jar'
+//    provided name: 'ImmersiveEngineering', version: config.immeng.version, ext: 'jar'
+
 }
 
 processResources

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ group= "gregtech"
 archivesBaseName = "gregtech"
 
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 minecraft {
     version = "${config.minecraft.version}-${config.forge.version}"

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ group= "gregtech"
 archivesBaseName = "gregtech"
 
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 minecraft {
     version = "${config.minecraft.version}-${config.forge.version}"

--- a/build.properties
+++ b/build.properties
@@ -25,3 +25,5 @@ immeng.cf=2299/20
 immeng.version=0.7.7-deobf
 magneticraft.cf=2276/268
 magneticraft.version=0.6.1-final
+tconstruct.version=1.8.4.build951
+translocators.version=1.1.2.16

--- a/build.properties
+++ b/build.properties
@@ -15,6 +15,7 @@ enderio.cf=2219/296
 enderio.version=1.7.10-2.3.0.417_beta
 enderiocore.version=1.7.10-0.1.0.25_beta
 forestry.version=4.2.10.58
+gc.version=1.7-3.0.12.504
 ic2.version=2.2.790-experimental
 nei.version=1.0.3.57
 railcraft.cf=2219/321

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -136,6 +136,7 @@ public class GT_Mod implements IGT_Mod {
         GregTech_API.mGTPlusPlus = Loader.isModLoaded("miscutils");
         GregTech_API.mTranslocator = Loader.isModLoaded("Translocator");
         GregTech_API.mTConstruct = Loader.isModLoaded("TConstruct");
+        GregTech_API.mGalacticraft = Loader.isModLoaded("GalacticraftCore");
         GT_Log.mLogFile = new File(aEvent.getModConfigurationDirectory().getParentFile(), "logs/GregTech.log");
         if (!GT_Log.mLogFile.exists()) {
             try {
@@ -184,7 +185,7 @@ public class GT_Mod implements IGT_Mod {
         gregtechproxy.onPreLoad();
         GT_Log.out.println("GT_Mod: Are you there Translocator? " + GregTech_API.mTranslocator);
         GT_Log.out.println("GT_Mod: Are you there TConstruct? " + GregTech_API.mTConstruct);
-
+        GT_Log.out.println("GT_Mod: Are you there GalacticraftCore? " + GregTech_API.mGalacticraft);
 
         GT_Log.out.println("GT_Mod: Setting Configs");
         GT_Values.D1 = tMainConfig.get(aTextGeneral, "Debug", false).getBoolean(false);
@@ -291,6 +292,7 @@ public class GT_Mod implements IGT_Mod {
         gregtechproxy.enableUBOres = GregTech_API.sWorldgenFile.get("general", "enableUBOres", gregtechproxy.enableUBOres);
         gregtechproxy.gt6Pipe = tMainConfig.get("general", "GT6StyledPipesConnection", true).getBoolean(true);
         gregtechproxy.gt6Cable = tMainConfig.get("general", "GT6StyledWiresConnection", true).getBoolean(true);
+        gregtechproxy.ic2EnergySourceCompat = tMainConfig.get("general", "Ic2EnergySourceCompat", true).getBoolean(true);
         gregtechproxy.costlyCableConnection = tMainConfig.get("general", "CableConnectionRequiresSolderingMaterial", false).getBoolean(false);
         GT_LanguageManager.i18nPlaceholder = tMainConfig.get("general", "UsePlaceholderForMaterialNamesInLangFile", true).getBoolean(true);
 

--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -59,7 +59,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-@Mod(modid = "gregtech", name = "GregTech", version = "MC1710", useMetadata = false, dependencies = "required-after:IC2; after:Forestry; after:PFAAGeologica; after:Thaumcraft; after:Railcraft; after:appliedenergistics2; after:ThermalExpansion; after:TwilightForest; after:harvestcraft; after:magicalcrops; after:BuildCraft|Transport; after:BuildCraft|Silicon; after:BuildCraft|Factory; after:BuildCraft|Energy; after:BuildCraft|Core; after:BuildCraft|Builders; after:GalacticraftCore; after:GalacticraftMars; after:GalacticraftPlanets; after:ThermalExpansion|Transport; after:ThermalExpansion|Energy; after:ThermalExpansion|Factory; after:RedPowerCore; after:RedPowerBase; after:RedPowerMachine; after:RedPowerCompat; after:RedPowerWiring; after:RedPowerLogic; after:RedPowerLighting; after:RedPowerWorld; after:RedPowerControl; after:UndergroundBiomes;")
+@Mod(modid = "gregtech", name = "GregTech", version = "MC1710", useMetadata = false, dependencies = "required-after:IC2; after:Forestry; after:PFAAGeologica; after:Thaumcraft; after:Railcraft; after:appliedenergistics2; after:ThermalExpansion; after:TwilightForest; after:harvestcraft; after:magicalcrops; after:BuildCraft|Transport; after:BuildCraft|Silicon; after:BuildCraft|Factory; after:BuildCraft|Energy; after:BuildCraft|Core; after:BuildCraft|Builders; after:GalacticraftCore; after:GalacticraftMars; after:GalacticraftPlanets; after:ThermalExpansion|Transport; after:ThermalExpansion|Energy; after:ThermalExpansion|Factory; after:RedPowerCore; after:RedPowerBase; after:RedPowerMachine; after:RedPowerCompat; after:RedPowerWiring; after:RedPowerLogic; after:RedPowerLighting; after:RedPowerWorld; after:RedPowerControl; after:UndergroundBiomes; after:TConstruct;  after:Translocator;")
 public class GT_Mod implements IGT_Mod {
     public static final int VERSION = 509, SUBVERSION = 31;
     public static final int TOTAL_VERSION = calculateTotalGTVersion(VERSION, SUBVERSION);
@@ -133,7 +133,9 @@ public class GT_Mod implements IGT_Mod {
         GregTech_API.mIC2Classic = Loader.isModLoaded("IC2-Classic-Spmod");
         GregTech_API.mMagneticraft = Loader.isModLoaded("Magneticraft");
         GregTech_API.mImmersiveEngineering = Loader.isModLoaded("ImmersiveEngineering");
-        GregTech_API.mGTPlusPlus = Loader.isModLoaded("miscutils");        
+        GregTech_API.mGTPlusPlus = Loader.isModLoaded("miscutils");
+        GregTech_API.mTranslocator = Loader.isModLoaded("Translocator");
+        GregTech_API.mTConstruct = Loader.isModLoaded("TConstruct");
         GT_Log.mLogFile = new File(aEvent.getModConfigurationDirectory().getParentFile(), "logs/GregTech.log");
         if (!GT_Log.mLogFile.exists()) {
             try {
@@ -180,6 +182,9 @@ public class GT_Mod implements IGT_Mod {
         } catch (Throwable e) {
         }
         gregtechproxy.onPreLoad();
+        GT_Log.out.println("GT_Mod: Are you there Translocator? " + GregTech_API.mTranslocator);
+        GT_Log.out.println("GT_Mod: Are you there TConstruct? " + GregTech_API.mTConstruct);
+
 
         GT_Log.out.println("GT_Mod: Setting Configs");
         GT_Values.D1 = tMainConfig.get(aTextGeneral, "Debug", false).getBoolean(false);
@@ -285,7 +290,7 @@ public class GT_Mod implements IGT_Mod {
         gregtechproxy.enableGCOres = GregTech_API.sWorldgenFile.get("general", "enableGCOres", gregtechproxy.enableGCOres);
         gregtechproxy.enableUBOres = GregTech_API.sWorldgenFile.get("general", "enableUBOres", gregtechproxy.enableUBOres);
         gregtechproxy.gt6Pipe = tMainConfig.get("general", "GT6StyledPipesConnection", true).getBoolean(true);
-        gregtechproxy.gt6Cable = tMainConfig.get("general", "GT6StyledWiresConnection", false).getBoolean(false);
+        gregtechproxy.gt6Cable = tMainConfig.get("general", "GT6StyledWiresConnection", true).getBoolean(true);
         gregtechproxy.costlyCableConnection = tMainConfig.get("general", "CableConnectionRequiresSolderingMaterial", false).getBoolean(false);
         GT_LanguageManager.i18nPlaceholder = tMainConfig.get("general", "UsePlaceholderForMaterialNamesInLangFile", true).getBoolean(true);
 

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -204,6 +204,7 @@ public class GregTech_API {
     public static boolean mGTPlusPlus = false;
     public static boolean mTranslocator = false;
     public static boolean mTConstruct = false;
+    public static boolean mGalacticraft = false;
 
     public static boolean mUseOnlyGoodSolderingMaterials = false;
 

--- a/src/main/java/gregtech/api/GregTech_API.java
+++ b/src/main/java/gregtech/api/GregTech_API.java
@@ -202,6 +202,8 @@ public class GregTech_API {
     public static boolean mMagneticraft = false;
     public static boolean mImmersiveEngineering = false;
     public static boolean mGTPlusPlus = false;
+    public static boolean mTranslocator = false;
+    public static boolean mTConstruct = false;
 
     public static boolean mUseOnlyGoodSolderingMaterials = false;
 

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
@@ -9,5 +9,7 @@ public interface IMetaTileEntityCable extends IMetaTileEntity {
     @Deprecated
     public long transferElectricity(byte aSide, long aVoltage, long aAmperage, ArrayList<TileEntity> aAlreadyPassedTileEntityList);
 
-    public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet);
+    default public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet) {
+        return transferElectricity(aSide, aVoltage, aAmperage, new ArrayList<>(aAlreadyPassedSet));
+    }
 }

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
@@ -3,7 +3,11 @@ package gregtech.api.interfaces.metatileentity;
 import net.minecraft.tileentity.TileEntity;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 
 public interface IMetaTileEntityCable extends IMetaTileEntity {
+    @Deprecated
     public long transferElectricity(byte aSide, long aVoltage, long aAmperage, ArrayList<TileEntity> aAlreadyPassedTileEntityList);
+
+    public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet);
 }

--- a/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
+++ b/src/main/java/gregtech/api/interfaces/metatileentity/IMetaTileEntityCable.java
@@ -9,7 +9,5 @@ public interface IMetaTileEntityCable extends IMetaTileEntity {
     @Deprecated
     public long transferElectricity(byte aSide, long aVoltage, long aAmperage, ArrayList<TileEntity> aAlreadyPassedTileEntityList);
 
-    default public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet) {
-        return transferElectricity(aSide, aVoltage, aAmperage, new ArrayList<>(aAlreadyPassedSet));
-    }
+    public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet);
 }

--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -35,16 +35,13 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
      * Sided Energy Input
      */
     public boolean inputEnergyFrom(byte aSide);
+    public boolean inputEnergyFrom(byte aSide, boolean waitForActive);
 
     /**
      * Sided Energy Output
      */
     public boolean outputsEnergyTo(byte aSide);
-
-    /**
-     * Are we ready for energy state?
-     */
-    public boolean energyStateReady();
+    public boolean outputsEnergyTo(byte aSide, boolean waitForActive);
 
     /**
      * Utility for the Network

--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -64,10 +64,6 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
                             if (tColor >= 0 && tColor != aEmitter.getColorization()) continue;
                         }
                         rUsedAmperes += ((IEnergyConnected) tTileEntity).injectEnergyUnits(j, aVoltage, aAmperage - rUsedAmperes);
-//				} else if (tTileEntity instanceof IEnergySink) {
-//	        		if (((IEnergySink)tTileEntity).acceptsEnergyFrom((TileEntity)aEmitter, ForgeDirection.getOrientation(j))) {
-//	        			while (aAmperage > rUsedAmperes && ((IEnergySink)tTileEntity).demandedEnergyUnits() > 0 && ((IEnergySink)tTileEntity).injectEnergyUnits(ForgeDirection.getOrientation(j), aVoltage) < aVoltage) rUsedAmperes++;
-//	        		}
                     } else if (tTileEntity instanceof IEnergySink) {
                         if (((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) aEmitter, ForgeDirection.getOrientation(j))) {
                             while (aAmperage > rUsedAmperes && ((IEnergySink) tTileEntity).getDemandedEnergy() > 0 && ((IEnergySink) tTileEntity).injectEnergy(ForgeDirection.getOrientation(j), aVoltage, aVoltage) < aVoltage)

--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -35,17 +35,13 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
      * Sided Energy Input
      */
     public boolean inputEnergyFrom(byte aSide);
-    default public boolean inputEnergyFrom(byte aSide, boolean waitForActive) {
-        return inputEnergyFrom(aSide);
-    }
+    public boolean inputEnergyFrom(byte aSide, boolean waitForActive);
 
     /**
      * Sided Energy Output
      */
     public boolean outputsEnergyTo(byte aSide);
-    default public boolean outputsEnergyTo(byte aSide, boolean waitForActive) {
-        return outputsEnergyTo(aSide);
-    }
+    public boolean outputsEnergyTo(byte aSide, boolean waitForActive);
 
     /**
      * Utility for the Network

--- a/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
+++ b/src/main/java/gregtech/api/interfaces/tileentity/IEnergyConnected.java
@@ -35,13 +35,17 @@ public interface IEnergyConnected extends IColoredTileEntity, IHasWorldObjectAnd
      * Sided Energy Input
      */
     public boolean inputEnergyFrom(byte aSide);
-    public boolean inputEnergyFrom(byte aSide, boolean waitForActive);
+    default public boolean inputEnergyFrom(byte aSide, boolean waitForActive) {
+        return inputEnergyFrom(aSide);
+    }
 
     /**
      * Sided Energy Output
      */
     public boolean outputsEnergyTo(byte aSide);
-    public boolean outputsEnergyTo(byte aSide, boolean waitForActive);
+    default public boolean outputsEnergyTo(byte aSide, boolean waitForActive) {
+        return outputsEnergyTo(aSide);
+    }
 
     /**
      * Utility for the Network

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaPipeEntity.java
@@ -9,7 +9,11 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.interfaces.tileentity.IPipeRenderedTileEntity;
 import gregtech.api.net.GT_Packet_TileEntity;
 import gregtech.api.objects.GT_ItemStack;
-import gregtech.api.util.*;
+import gregtech.api.util.GT_CoverBehavior;
+import gregtech.api.util.GT_Log;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
@@ -25,6 +29,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
+import net.minecraftforge.fluids.IFluidHandler;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,6 +49,7 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     private byte[] mSidedRedstone = new byte[]{0, 0, 0, 0, 0, 0};
     private int[] mCoverSides = new int[]{0, 0, 0, 0, 0, 0}, mCoverData = new int[]{0, 0, 0, 0, 0, 0}, mTimeStatistics = new int[GregTech_API.TICKS_FOR_LAG_AVERAGING];
     private boolean mInventoryChanged = false, mWorkUpdate = false, mWorks = true, mNeedsUpdate = true, mNeedsBlockUpdate = true, mSendClientData = false;
+    private boolean mCheckConnections = false;
     private byte mColor = 0, oColor = 0, mStrongRedstone = 0, oRedstoneData = 63, oTextureData = 0, oUpdateData = 0, mLagWarningCount = 0;
     private int oX = 0, oY = 0, oZ = 0, mTimeStatisticsIndex = 0;
     private short mID = 0;
@@ -636,7 +642,17 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     }
 
     @Override
+    public boolean inputEnergyFrom(byte aSide, boolean waitForActive) {
+        return false;
+    }
+
+    @Override
     public boolean outputsEnergyTo(byte aSide) {
+        return false;
+    }
+
+    @Override
+    public boolean outputsEnergyTo(byte aSide, boolean waitForActive) {
         return false;
     }
 
@@ -1177,7 +1193,9 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         if (aSide == ForgeDirection.UNKNOWN)
         	return true;
 
-        if (!mMetaTileEntity.isConnectedAtSide((byte) aSide.ordinal()))
+        IFluidHandler tTileEntity = getITankContainerAtSide((byte) aSide.ordinal());
+        // Only require a connection if there's something to connect to - Allows fluid cells & buckets to interact with the pipe
+        if (tTileEntity != null && !mMetaTileEntity.isConnectedAtSide((byte) aSide.ordinal()))
             return false;
 
         if(isFill && mMetaTileEntity.isLiquidInput((byte) aSide.ordinal())
@@ -1275,8 +1293,9 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     @Override
     public byte setColorization(byte aColor) {
         if (aColor > 15 || aColor < -1) aColor = -1;
+        mColor = (byte) (aColor + 1);
         if (canAccessData()) mMetaTileEntity.onColorChangeServer(aColor);
-        return mColor = (byte) (aColor + 1);
+        return mColor;
     }
 
     @Override
@@ -1334,6 +1353,18 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
         mInventoryChanged = true;
     }
 
+    public void onNeighborBlockChange(int aX, int aY, int aZ) {
+        if (canAccessData()) {
+            final IMetaTileEntity meta = getMetaTileEntity();
+            if (meta instanceof MetaPipeEntity) {
+                // Trigger a checking of connections in case someone placed down a block that the pipe/wire shouldn't be connected to.
+                // However; don't do it immediately in case the world isn't finished loading
+                //  (This caused issues with AE2 GTEU p2p connections.
+                ((MetaPipeEntity) meta).setCheckConnections();
+            }
+        }
+    }
+
     @Override
     public int getLightOpacity() {
         return mMetaTileEntity == null ? 0 : mMetaTileEntity.getLightOpacity();
@@ -1353,9 +1384,4 @@ public class BaseMetaPipeEntity extends BaseTileEntity implements IGregTechTileE
     public void onEntityCollidedWithBlock(World aWorld, int aX, int aY, int aZ, Entity collider) {
         mMetaTileEntity.onEntityCollidedWithBlock(aWorld, aX, aY, aZ, collider);
     }
-
-	@Override
-	public boolean energyStateReady() {
-		return true;
-	}
 }

--- a/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/BaseMetaTileEntity.java
@@ -972,6 +972,7 @@ public class BaseMetaTileEntity extends BaseTileEntity implements IGregTechTileE
         return inputEnergyFrom(aSide, true);
     }
 
+    @Override
     public boolean inputEnergyFrom(byte aSide, boolean waitForActive) {
         if (aSide == 6) return true;
         if (isServerSide() && waitForActive) return ((aSide >= 0 && aSide < 6) && mActiveEUInputs[aSide]) && !mReleaseEnergy;

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -744,7 +744,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 
 		final byte tSide = GT_Utility.getOppositeSide(aSide);
 		final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
-		if (baseMetaTile == null) return 0;
+		if (baseMetaTile == null || !baseMetaTile.isServerSide()) return 0;
 
         final GT_CoverBehavior coverBehavior = baseMetaTile.getCoverBehaviorAtSide(aSide);
         final int coverId = baseMetaTile.getCoverIDAtSide(aSide),

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -6,9 +6,12 @@ import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
 import gregtech.api.interfaces.metatileentity.IConnectable;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IColoredTileEntity;
+import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.util.GT_Config;
+import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_LanguageManager;
 import gregtech.api.util.GT_Utility;
 import net.minecraft.block.Block;
@@ -21,6 +24,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -56,6 +60,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
      * This variable tells, which directions the Block is connected to. It is a Bitmask.
      */
     public byte mConnections = 0;
+    protected boolean mCheckConnections = false;
     /**
      * Only assigned for the MetaTileEntity in the List! Also only used to get the localized Name for the ItemStack and for getInvName.
      */
@@ -326,12 +331,12 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 
     @Override
     public boolean isLiquidInput(byte aSide) {
-        return true;
+        return false;
     }
 
     @Override
     public boolean isLiquidOutput(byte aSide) {
-        return true;
+        return false;
     }
 
     /**
@@ -635,12 +640,16 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 
     @Override
     public void onColorChangeServer(byte aColor) {
-        //
+        setCheckConnections();
     }
 
     @Override
     public void onColorChangeClient(byte aColor) {
-        //
+        // Do nothing apparently
+    }
+
+    public void setCheckConnections() {
+        mCheckConnections = true;
     }
 
     public long injectEnergyUnits(byte aSide, long aVoltage, long aAmperage) {
@@ -715,17 +724,79 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
     	return GT_LanguageManager.addStringLocalization("Interaction_DESCRIPTION_Index_"+aKey, aEnglish, false);
     }
 
+    private boolean connectableColor(TileEntity tTileEntity) {
+        // Determine if two entities are connectable based on their colorization:
+        //  Uncolored can connect to anything
+        //  If both are colored they must be the same color to connect.
+        if (tTileEntity instanceof IColoredTileEntity) {
+            if (getBaseMetaTileEntity().getColorization() >= 0) {
+                byte tColor = ((IColoredTileEntity) tTileEntity).getColorization();
+                if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization()) return false;
+            }
+        }
+
+        return true;
+    }
+
 	@Override
 	public int connect(byte aSide) {
 		if (aSide >= 6) return 0;
-		mConnections |= (1 << aSide);
-		byte tSide = GT_Utility.getOppositeSide(aSide);
-		IGregTechTileEntity tTileEntity = getBaseMetaTileEntity().getIGregTechTileEntityAtSide(aSide);
-		IMetaTileEntity tPipe = tTileEntity instanceof IGregTechTileEntity ? ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() : null;
-		if (this.getClass().isInstance(tPipe) && !((MetaPipeEntity) tPipe).isConnectedAtSide(tSide))
-			((MetaPipeEntity) tPipe).connect(tSide);
-    	return 1;
+
+		final byte tSide = GT_Utility.getOppositeSide(aSide);
+		final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
+		if (baseMetaTile == null) return 0;
+
+        final GT_CoverBehavior coverBehavior = baseMetaTile.getCoverBehaviorAtSide(aSide);
+        final int coverId = baseMetaTile.getCoverIDAtSide(aSide),
+                  coverData = baseMetaTile.getCoverDataAtSide(aSide);
+
+        boolean alwaysLookConnected = coverBehavior.alwaysLookConnected(aSide, coverId, coverData, baseMetaTile);
+        boolean letsIn = letsIn(coverBehavior, aSide, coverId, coverData, baseMetaTile);
+        boolean letsOut = letsOut(coverBehavior, aSide, coverId, coverData, baseMetaTile);
+
+        // Careful - tTileEntity might be null, and that's ok -- so handle it
+        TileEntity tTileEntity = baseMetaTile.getTileEntityAtSide(aSide);
+        if (!connectableColor(tTileEntity)) return 0;
+
+        if ((alwaysLookConnected || letsIn || letsOut))  {
+            // Are we trying to connect to a pipe? let's do it!
+            IMetaTileEntity tPipe = tTileEntity instanceof IGregTechTileEntity ? ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() : null;
+            if (getClass().isInstance(tPipe)) {
+                connectAtSide(aSide);
+                if (!((MetaPipeEntity) tPipe).isConnectedAtSide(tSide)) {
+                    // Make sure pipes all get together -- connect back to us if we're connecting to a pipe
+                    ((MetaPipeEntity) tPipe).connect(tSide);
+                }
+                return 1;
+            }
+            else if((getGT6StyleConnection() && baseMetaTile.getAirAtSide(aSide)) || canConnect(aSide, tTileEntity)) {
+                // Allow open connections to Air, if the GT6 style pipe/cables are enabled, so that it'll connect to the next block placed down next to it
+                connectAtSide(aSide);
+                return 1;
+            }
+            if (!baseMetaTile.getWorld().getChunkProvider().chunkExists(baseMetaTile.getOffsetX(aSide, 1) >> 4, baseMetaTile.getOffsetZ(aSide, 1) >> 4)) {
+                // Target chunk unloaded
+                return -1;
+            }
+
+        }
+    	return 0;
 	}
+
+    protected void checkConnections() {
+        // Verify connections around us.  If GT6 style cables are not enabled then revert to old behavior and try
+        // connecting to everything around us
+        for (byte aSide = 0; aSide < 6; aSide++) {
+            if ((!getGT6StyleConnection() || isConnectedAtSide(aSide)) && connect(aSide) == 0) {
+                disconnect(aSide);
+            }
+        }
+        mCheckConnections = false;
+    }
+
+	private void connectAtSide(byte aSide) {
+        mConnections |= (1 << aSide);
+    }
 
 	@Override
 	public void disconnect(byte aSide) {
@@ -734,12 +805,18 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 		byte tSide = GT_Utility.getOppositeSide(aSide);
 		IGregTechTileEntity tTileEntity = getBaseMetaTileEntity().getIGregTechTileEntityAtSide(aSide);
 		IMetaTileEntity tPipe = tTileEntity == null ? null : tTileEntity.getMetaTileEntity(); 
-		if (this.getClass().isInstance(tPipe) && (((MetaPipeEntity) tPipe).mConnections & (1 << tSide)) != 0)
+		if (this.getClass().isInstance(tPipe) && ((MetaPipeEntity) tPipe).isConnectedAtSide(tSide))
 			((MetaPipeEntity) tPipe).disconnect(tSide);
 	}
 
-	@Override
 	public boolean isConnectedAtSide(int aSide) {
 		return (mConnections & (1 << aSide)) != 0;
 	}
+
+
+	public boolean letsIn(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) { return false; }
+    public boolean letsOut(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) { return false; }
+
+	public boolean canConnect(byte aSide, TileEntity tTileEntity) { return false; }
+	public boolean getGT6StyleConnection() { return false; }
 }

--- a/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaPipeEntity.java
@@ -761,7 +761,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
         if ((alwaysLookConnected || letsIn || letsOut))  {
             // Are we trying to connect to a pipe? let's do it!
             IMetaTileEntity tPipe = tTileEntity instanceof IGregTechTileEntity ? ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() : null;
-            if (getClass().isInstance(tPipe)) {
+            if (getClass().isInstance(tPipe) || (tPipe != null && tPipe.getClass().isInstance(this))) {
                 connectAtSide(aSide);
                 if (!((MetaPipeEntity) tPipe).isConnectedAtSide(tSide)) {
                     // Make sure pipes all get together -- connect back to us if we're connecting to a pipe
@@ -805,7 +805,7 @@ public abstract class MetaPipeEntity implements IMetaTileEntity, IConnectable {
 		byte tSide = GT_Utility.getOppositeSide(aSide);
 		IGregTechTileEntity tTileEntity = getBaseMetaTileEntity().getIGregTechTileEntityAtSide(aSide);
 		IMetaTileEntity tPipe = tTileEntity == null ? null : tTileEntity.getMetaTileEntity(); 
-		if (this.getClass().isInstance(tPipe) && ((MetaPipeEntity) tPipe).isConnectedAtSide(tSide))
+		if ((this.getClass().isInstance(tPipe) || (tPipe != null && tPipe.getClass().isInstance(this))) && ((MetaPipeEntity) tPipe).isConnectedAtSide(tSide))
 			((MetaPipeEntity) tPipe).disconnect(tSide);
 	}
 

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntity.java
@@ -832,12 +832,20 @@ public abstract class MetaTileEntity implements IMetaTileEntity {
 
     @Override
     public void onColorChangeServer(byte aColor) {
-        //
+        final IGregTechTileEntity meta = getBaseMetaTileEntity();
+        final int aX = meta.getXCoord(), aY = meta.getYCoord(), aZ = meta.getZCoord();
+        for (byte aSide = 0; aSide < 6 ; aSide++ ) {
+            // Flag surrounding pipes/cables to revaluate their connection with us if we got painted
+            final TileEntity tTileEntity = meta.getTileEntityAtSide(aSide);
+            if ((tTileEntity instanceof BaseMetaPipeEntity)) {
+                ((BaseMetaPipeEntity) tTileEntity).onNeighborBlockChange(aX, aY, aZ);
+            }
+        }
     }
 
     @Override
     public void onColorChangeClient(byte aColor) {
-        //
+        // Do nothing apparently
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -1,8 +1,8 @@
 package gregtech.api.metatileentity.implementations;
 
 import cofh.api.energy.IEnergyReceiver;
+import com.google.common.collect.Sets;
 import gregtech.GT_Mod;
-import static gregtech.api.enums.GT_Values.D1;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.Materials;
@@ -11,7 +11,6 @@ import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntityCable;
-import gregtech.api.interfaces.tileentity.IColoredTileEntity;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.interfaces.tileentity.IEnergyConnected;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
@@ -19,15 +18,23 @@ import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_CoverBehavior;
-import gregtech.api.util.GT_Log;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Client;
 import gregtech.common.covers.GT_Cover_SolarPanel;
 import gregtech.loaders.postload.PartP2PGTPower;
+import ic2.api.energy.EnergyNet;
 import ic2.api.energy.tile.IEnergyEmitter;
 import ic2.api.energy.tile.IEnergySink;
 import ic2.api.energy.tile.IEnergySource;
+import ic2.api.energy.tile.IEnergyTile;
+import ic2.api.reactor.IReactorChamber;
+import micdoodle8.mods.galacticraft.api.power.EnergySource;
+import micdoodle8.mods.galacticraft.api.power.EnergySource.EnergySourceAdjacent;
+import micdoodle8.mods.galacticraft.api.power.IEnergyHandlerGC;
+import micdoodle8.mods.galacticraft.api.transmission.NetworkType;
+import micdoodle8.mods.galacticraft.api.transmission.tile.IConnector;
+import micdoodle8.mods.galacticraft.core.energy.EnergyConfigHandler;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -40,7 +47,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import appeng.api.parts.IPartHost;
@@ -148,79 +155,181 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
         return (int) mAmperage * 64;
     }
 
+    private void pullFromIc2EnergySources(IGregTechTileEntity aBaseMetaTileEntity) {
+        if(!GT_Mod.gregtechproxy.ic2EnergySourceCompat) return;
+
+        for( byte aSide = 0 ; aSide < 6 ; aSide++) if(isConnectedAtSide(aSide)) {
+            final TileEntity tTileEntity = aBaseMetaTileEntity.getTileEntityAtSide(aSide);
+            final TileEntity tEmitter;
+            if (tTileEntity instanceof IReactorChamber)
+                tEmitter = (TileEntity) ((IReactorChamber) tTileEntity).getReactor();
+            else tEmitter = (tTileEntity == null || tTileEntity instanceof IEnergyTile || EnergyNet.instance == null) ? tTileEntity :
+                EnergyNet.instance.getTileEntity(tTileEntity.getWorldObj(), tTileEntity.xCoord, tTileEntity.yCoord, tTileEntity.zCoord);
+
+            if (tEmitter instanceof IEnergySource) {
+                final GT_CoverBehavior coverBehavior = aBaseMetaTileEntity.getCoverBehaviorAtSide(aSide);
+                final int coverId = aBaseMetaTileEntity.getCoverIDAtSide(aSide),
+                    coverData = aBaseMetaTileEntity.getCoverDataAtSide(aSide);
+                final ForgeDirection tDirection = ForgeDirection.getOrientation(GT_Utility.getOppositeSide(aSide));
+
+                if (((IEnergySource) tEmitter).emitsEnergyTo((TileEntity) aBaseMetaTileEntity, tDirection) &&
+                    coverBehavior.letsEnergyIn(aSide, coverId, coverData, aBaseMetaTileEntity)) {
+                    final long tEU = (long) ((IEnergySource) tEmitter).getOfferedEnergy();
+
+                    if (transferElectricity(aSide, tEU, 1, Sets.newHashSet((TileEntity) aBaseMetaTileEntity)) > 0)
+                        ((IEnergySource) tEmitter).drawEnergy(tEU);
+                }
+            }
+        }
+    }
+
     @Override
     public long injectEnergyUnits(byte aSide, long aVoltage, long aAmperage) {
     	if (!isConnectedAtSide(aSide) && aSide != 6)
     		return 0;
         if (!getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsEnergyIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), getBaseMetaTileEntity()))
             return 0;
-        return transferElectricity(aSide, aVoltage, aAmperage, new ArrayList<TileEntity>(Arrays.asList((TileEntity) getBaseMetaTileEntity())));
+        return transferElectricity(aSide, aVoltage, aAmperage, Sets.newHashSet((TileEntity) getBaseMetaTileEntity()));
     }
 
     @Override
+    @Deprecated
     public long transferElectricity(byte aSide, long aVoltage, long aAmperage, ArrayList<TileEntity> aAlreadyPassedTileEntityList) {
-    	if (!isConnectedAtSide(aSide) && aSide != 6)
-    		return 0;
+        return transferElectricity(aSide, aVoltage, aAmperage, new HashSet<>(aAlreadyPassedTileEntityList));
+    }
+
+    @Override
+    public long transferElectricity(byte aSide, long aVoltage, long aAmperage, HashSet<TileEntity> aAlreadyPassedSet) {
+        if (!isConnectedAtSide(aSide) && aSide != 6) return 0;
+
         long rUsedAmperes = 0;
+        final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
+
         aVoltage -= mCableLossPerMeter;
         if (aVoltage > 0) for (byte i = 0; i < 6 && aAmperage > rUsedAmperes; i++)
-            if (i != aSide && isConnectedAtSide(i) && getBaseMetaTileEntity().getCoverBehaviorAtSide(i).letsEnergyOut(i, getBaseMetaTileEntity().getCoverIDAtSide(i), getBaseMetaTileEntity().getCoverDataAtSide(i), getBaseMetaTileEntity())) {
-                TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(i);
-                if (!aAlreadyPassedTileEntityList.contains(tTileEntity)) {
-                    aAlreadyPassedTileEntityList.add(tTileEntity);
-                    if (tTileEntity instanceof IEnergyConnected) {
-                        if (getBaseMetaTileEntity().getColorization() >= 0) {
-                            byte tColor = ((IEnergyConnected) tTileEntity).getColorization();
-                            if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization()) continue;
+            if (i != aSide && isConnectedAtSide(i) && baseMetaTile.getCoverBehaviorAtSide(i).letsEnergyOut(i, baseMetaTile.getCoverIDAtSide(i), baseMetaTile.getCoverDataAtSide(i), baseMetaTile)) {
+                final TileEntity tTileEntity = baseMetaTile.getTileEntityAtSide(i);
+
+                if (tTileEntity != null && aAlreadyPassedSet.add(tTileEntity)) {
+                    final byte tSide = GT_Utility.getOppositeSide(i);
+                    final IGregTechTileEntity tBaseMetaTile = tTileEntity instanceof IGregTechTileEntity ? ((IGregTechTileEntity) tTileEntity) : null;
+                    final IMetaTileEntity tMeta = tBaseMetaTile != null ? tBaseMetaTile.getMetaTileEntity() : null;
+
+                    if (tMeta instanceof IMetaTileEntityCable) {
+                        if (tBaseMetaTile.getCoverBehaviorAtSide(tSide).letsEnergyIn(tSide, tBaseMetaTile.getCoverIDAtSide(tSide), tBaseMetaTile.getCoverDataAtSide(tSide), tBaseMetaTile) && ((IGregTechTileEntity) tTileEntity).getTimer() > 50) {
+                            rUsedAmperes += ((IMetaTileEntityCable) ((IGregTechTileEntity) tTileEntity).getMetaTileEntity()).transferElectricity(tSide, aVoltage, aAmperage - rUsedAmperes, aAlreadyPassedSet);
                         }
-                        if (tTileEntity instanceof IGregTechTileEntity && ((IGregTechTileEntity) tTileEntity).getMetaTileEntity() instanceof IMetaTileEntityCable && ((IGregTechTileEntity) tTileEntity).getCoverBehaviorAtSide(GT_Utility.getOppositeSide(i)).letsEnergyIn(GT_Utility.getOppositeSide(i), ((IGregTechTileEntity) tTileEntity).getCoverIDAtSide(GT_Utility.getOppositeSide(i)), ((IGregTechTileEntity) tTileEntity).getCoverDataAtSide(GT_Utility.getOppositeSide(i)), ((IGregTechTileEntity) tTileEntity))) {
-                            if (((IGregTechTileEntity) tTileEntity).getTimer() > 50)
-                                rUsedAmperes += ((IMetaTileEntityCable) ((IGregTechTileEntity) tTileEntity).getMetaTileEntity()).transferElectricity(GT_Utility.getOppositeSide(i), aVoltage, aAmperage - rUsedAmperes, aAlreadyPassedTileEntityList);
-                        } else {
-                            rUsedAmperes += ((IEnergyConnected) tTileEntity).injectEnergyUnits(GT_Utility.getOppositeSide(i), aVoltage, aAmperage - rUsedAmperes);
-                        }
-                    } else if (tTileEntity instanceof IEnergySink) {
-                        ForgeDirection tDirection = ForgeDirection.getOrientation(i).getOpposite();
-                        if (((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), tDirection)) {
-                            if (((IEnergySink) tTileEntity).getDemandedEnergy() > 0 && ((IEnergySink) tTileEntity).injectEnergy(tDirection, aVoltage, aVoltage) < aVoltage)
-                                rUsedAmperes++;
-                        }
-                    } else if (GregTech_API.mOutputRF && tTileEntity instanceof IEnergyReceiver) {
-                        ForgeDirection tDirection = ForgeDirection.getOrientation(i).getOpposite();
-                        int rfOut = (int) (aVoltage * GregTech_API.mEUtoRF / 100);
-                        if (((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, rfOut, true) == rfOut) {
-                            ((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, rfOut, false);
-                            rUsedAmperes++;
-                        } else if (((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, rfOut, true) > 0) {
-                            if (mRestRF == 0) {
-                                int RFtrans = ((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, (int) rfOut, false);
-                                rUsedAmperes++;
-                                mRestRF = rfOut - RFtrans;
-                            } else {
-                                int RFtrans = ((IEnergyReceiver) tTileEntity).receiveEnergy(tDirection, (int) mRestRF, false);
-                                mRestRF = mRestRF - RFtrans;
-                            }
-                        }
-                        if (GregTech_API.mRFExplosions && ((IEnergyReceiver) tTileEntity).getMaxEnergyStored(tDirection) < rfOut * 600) {
-                            if (rfOut > 32 * GregTech_API.mEUtoRF / 100) this.doExplosion(rfOut);
-                        }
+                    } else {
+                        rUsedAmperes += insertEnergyInto(tTileEntity, tSide, aVoltage, aAmperage - rUsedAmperes);
                     }
+
                 }
             }
         mTransferredAmperage += rUsedAmperes;
         mTransferredVoltageLast20 = Math.max(mTransferredVoltageLast20, aVoltage);
         mTransferredAmperageLast20 = Math.max(mTransferredAmperageLast20, mTransferredAmperage);
         if (aVoltage > mVoltage || mTransferredAmperage > mAmperage) {
-        	if(mOverheat>GT_Mod.gregtechproxy.mWireHeatingTicks * 100){
-            getBaseMetaTileEntity().setToFire();}else{mOverheat +=100;}
+            if (mOverheat > GT_Mod.gregtechproxy.mWireHeatingTicks * 100) {
+                getBaseMetaTileEntity().setToFire();
+            } else {
+                mOverheat += 100;
+            }
             return aAmperage;
         }
         return rUsedAmperes;
     }
 
+    private long insertEnergyInto(TileEntity tTileEntity, byte tSide, long aVoltage, long aAmperage) {
+        if (aAmperage == 0 || tTileEntity == null) return 0;
+
+        final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
+        final ForgeDirection tDirection = ForgeDirection.getOrientation(tSide);
+
+        if (tTileEntity instanceof IEnergyConnected) {
+            return ((IEnergyConnected) tTileEntity).injectEnergyUnits(tSide, aVoltage, aAmperage);
+        }
+
+        // AE2 Compat
+        if (GT_Mod.gregtechproxy.mAE2Integration && tTileEntity instanceof appeng.tile.powersink.IC2) {
+            if (((appeng.tile.powersink.IC2) tTileEntity).acceptsEnergyFrom((TileEntity) baseMetaTile, tDirection)) {
+                long rUsedAmperes = 0;
+                while (aAmperage > rUsedAmperes && ((appeng.tile.powersink.IC2)tTileEntity).getDemandedEnergy() > 0 && ((appeng.tile.powersink.IC2)tTileEntity).injectEnergy(tDirection, aVoltage, aVoltage) <= aVoltage)
+                    rUsedAmperes++;
+
+                return rUsedAmperes;
+            }
+            return 0;
+        }
+
+        // GC Compat
+        if (GregTech_API.mGalacticraft && tTileEntity instanceof IEnergyHandlerGC) {
+            if (!(tTileEntity instanceof IConnector) || ((IConnector)tTileEntity).canConnect(tDirection, NetworkType.POWER)) {
+                EnergySource eSource = new EnergySourceAdjacent(tDirection);
+
+                float tSizeToReceive = aVoltage * EnergyConfigHandler.IC2_RATIO, tStored = ((IEnergyHandlerGC)tTileEntity).getEnergyStoredGC(eSource);
+                if (tSizeToReceive >= tStored || tSizeToReceive <= ((IEnergyHandlerGC)tTileEntity).getMaxEnergyStoredGC(eSource) - tStored) {
+                    float tReceived = ((IEnergyHandlerGC)tTileEntity).receiveEnergyGC(eSource, tSizeToReceive, false);
+                    if (tReceived > 0) {
+                        tSizeToReceive -= tReceived;
+                        while (tSizeToReceive > 0) {
+                            tReceived = ((IEnergyHandlerGC)tTileEntity).receiveEnergyGC(eSource, tSizeToReceive, false);
+                            if (tReceived < 1) break;
+                            tSizeToReceive -= tReceived;
+                        }
+                        return 1;
+                    }
+                }
+            }
+            return 0;
+        }
+
+        // IC2 Compat
+        {
+            final TileEntity tIc2Acceptor = (tTileEntity instanceof IEnergyTile || EnergyNet.instance == null) ? tTileEntity :
+                EnergyNet.instance.getTileEntity(tTileEntity.getWorldObj(), tTileEntity.xCoord, tTileEntity.yCoord, tTileEntity.zCoord);
+
+            if (tIc2Acceptor instanceof IEnergySink && ((IEnergySink) tIc2Acceptor).acceptsEnergyFrom((TileEntity) baseMetaTile, tDirection)) {
+                long rUsedAmperes = 0;
+                while (aAmperage > rUsedAmperes && ((IEnergySink) tIc2Acceptor).getDemandedEnergy() > 0 && ((IEnergySink) tIc2Acceptor).injectEnergy(tDirection, aVoltage, aVoltage) <= aVoltage)
+                    rUsedAmperes++;
+                return rUsedAmperes;
+            }
+        }
+
+        // RF Compat
+        if (GregTech_API.mOutputRF && tTileEntity instanceof IEnergyReceiver) {
+            final IEnergyReceiver rfReceiver = (IEnergyReceiver) tTileEntity;
+            long rfOUT = aVoltage * GregTech_API.mEUtoRF / 100, rUsedAmperes = 0;
+            int rfOut = rfOUT > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) rfOUT;
+
+            if (rfReceiver.receiveEnergy(tDirection, rfOut, true) == rfOut) {
+                rfReceiver.receiveEnergy(tDirection, rfOut, false);
+                rUsedAmperes++;
+            }
+            else if (rfReceiver.receiveEnergy(tDirection, rfOut, true) > 0) {
+                if (mRestRF == 0) {
+                    int RFtrans = rfReceiver.receiveEnergy(tDirection, (int) rfOut, false);
+                    rUsedAmperes++;
+                    mRestRF = rfOut - RFtrans;
+                } else {
+                    int RFtrans = rfReceiver.receiveEnergy(tDirection, (int) mRestRF, false);
+                    mRestRF = mRestRF - RFtrans;
+                }
+            }
+            if (GregTech_API.mRFExplosions && rfReceiver.getMaxEnergyStored(tDirection) < rfOut * 600) {
+                if (rfOut > 32 * GregTech_API.mEUtoRF / 100) this.doExplosion(rfOut);
+            }
+            return rUsedAmperes;
+        }
+
+        return 0;
+    }
+
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
         if (aBaseMetaTileEntity.isServerSide()) {
+            if (GT_Mod.gregtechproxy.ic2EnergySourceCompat) pullFromIc2EnergySources(aBaseMetaTileEntity);
+
             mTransferredAmperage = 0;
             if(mOverheat>0)mOverheat--;
             if (aTick % 20 == 0) {
@@ -273,8 +382,8 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
     @Override
     public boolean canConnect(byte aSide, TileEntity tTileEntity) {
-        final IGregTechTileEntity gTileEntity = (tTileEntity instanceof IGregTechTileEntity) ? (IGregTechTileEntity) tTileEntity : null;
-        final GT_CoverBehavior coverBehavior = getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide);
+        final IGregTechTileEntity baseMetaTile = getBaseMetaTileEntity();
+        final GT_CoverBehavior coverBehavior = baseMetaTile.getCoverBehaviorAtSide(aSide);
         final byte tSide = GT_Utility.getOppositeSide(aSide);
         final ForgeDirection tDir = ForgeDirection.getOrientation(tSide);
 
@@ -288,22 +397,45 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
 
         // ((tIsGregTechTileEntity && tIsTileEntityCable) && (tAlwaysLookConnected || tLetEnergyIn || tLetEnergyOut) ) --> Not needed
 
-        // IC2 Compat
-        if ((tTileEntity instanceof IEnergySink) && ((IEnergySink) tTileEntity).acceptsEnergyFrom((TileEntity) getBaseMetaTileEntity(), tDir))
+        // GC Compat
+        if (GregTech_API.mGalacticraft && tTileEntity instanceof IEnergyHandlerGC && (!(tTileEntity instanceof IConnector) || ((IConnector)tTileEntity).canConnect(tDir, NetworkType.POWER)))
             return true;
 
         // AE2-p2p Compat
-        if (GT_Mod.gregtechproxy.mAE2Integration && tTileEntity instanceof IEnergySource &&
-            tTileEntity instanceof IPartHost && ((IPartHost)tTileEntity).getPart(tDir) instanceof PartP2PGTPower &&
-            ((IEnergySource) tTileEntity).emitsEnergyTo((TileEntity) getBaseMetaTileEntity(), tDir))
-            return true;
+        if (GT_Mod.gregtechproxy.mAE2Integration) {
+            if (tTileEntity instanceof IEnergySource && tTileEntity instanceof IPartHost && ((IPartHost)tTileEntity).getPart(tDir) instanceof PartP2PGTPower && ((IEnergySource) tTileEntity).emitsEnergyTo((TileEntity) baseMetaTile, tDir))
+                return true;
+            if (tTileEntity instanceof appeng.tile.powersink.IC2 && ((appeng.tile.powersink.IC2)tTileEntity).acceptsEnergyFrom((TileEntity)baseMetaTile, tDir))
+                return true;
+        }
 
+        // IC2 Compat
+        {
+            final TileEntity ic2Energy;
+
+            if (tTileEntity instanceof IReactorChamber)
+                ic2Energy = (TileEntity) ((IReactorChamber) tTileEntity).getReactor();
+            else
+                ic2Energy = (tTileEntity == null || tTileEntity instanceof IEnergyTile || EnergyNet.instance == null) ? tTileEntity :
+                    EnergyNet.instance.getTileEntity(tTileEntity.getWorldObj(), tTileEntity.xCoord, tTileEntity.yCoord, tTileEntity.zCoord);
+
+            // IC2 Sink Compat
+            if ((ic2Energy instanceof IEnergySink) && ((IEnergySink) ic2Energy).acceptsEnergyFrom((TileEntity) baseMetaTile, tDir))
+                return true;
+
+            // IC2 Source Compat
+            if (GT_Mod.gregtechproxy.ic2EnergySourceCompat && (ic2Energy instanceof IEnergySource)) {
+                if (((IEnergySource) ic2Energy).emitsEnergyTo((TileEntity) baseMetaTile, tDir)) {
+                    return true;
+                }
+            }
+        }
         // RF Output Compat
         if (GregTech_API.mOutputRF && tTileEntity instanceof IEnergyReceiver && ((IEnergyReceiver) tTileEntity).canConnectEnergy(tDir))
             return true;
 
         // RF Input Compat
-        if (GregTech_API.mInputRF && (tTileEntity instanceof IEnergyEmitter && ((IEnergyEmitter) tTileEntity).emitsEnergyTo((TileEntity)getBaseMetaTileEntity(), tDir)))
+        if (GregTech_API.mInputRF && (tTileEntity instanceof IEnergyEmitter && ((IEnergyEmitter) tTileEntity).emitsEnergyTo((TileEntity)baseMetaTile, tDir)))
             return true;
 
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Cable.java
@@ -262,25 +262,27 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
         }
 
         // GC Compat
-        if (GregTech_API.mGalacticraft && tTileEntity instanceof IEnergyHandlerGC) {
-            if (!(tTileEntity instanceof IConnector) || ((IConnector)tTileEntity).canConnect(tDirection, NetworkType.POWER)) {
-                EnergySource eSource = new EnergySourceAdjacent(tDirection);
+        if (GregTech_API.mGalacticraft) {
+            if (tTileEntity instanceof IEnergyHandlerGC) {
+                if (!(tTileEntity instanceof IConnector) || ((IConnector) tTileEntity).canConnect(tDirection, NetworkType.POWER)) {
+                    EnergySource eSource = (EnergySource) GT_Utility.callConstructor("micdoodle8.mods.galacticraft.api.power.EnergySource.EnergySourceAdjacent", 0, null, false, new Object[]{tDirection});
 
-                float tSizeToReceive = aVoltage * EnergyConfigHandler.IC2_RATIO, tStored = ((IEnergyHandlerGC)tTileEntity).getEnergyStoredGC(eSource);
-                if (tSizeToReceive >= tStored || tSizeToReceive <= ((IEnergyHandlerGC)tTileEntity).getMaxEnergyStoredGC(eSource) - tStored) {
-                    float tReceived = ((IEnergyHandlerGC)tTileEntity).receiveEnergyGC(eSource, tSizeToReceive, false);
-                    if (tReceived > 0) {
-                        tSizeToReceive -= tReceived;
-                        while (tSizeToReceive > 0) {
-                            tReceived = ((IEnergyHandlerGC)tTileEntity).receiveEnergyGC(eSource, tSizeToReceive, false);
-                            if (tReceived < 1) break;
+                    float tSizeToReceive = aVoltage * EnergyConfigHandler.IC2_RATIO, tStored = ((IEnergyHandlerGC) tTileEntity).getEnergyStoredGC(eSource);
+                    if (tSizeToReceive >= tStored || tSizeToReceive <= ((IEnergyHandlerGC) tTileEntity).getMaxEnergyStoredGC(eSource) - tStored) {
+                        float tReceived = ((IEnergyHandlerGC) tTileEntity).receiveEnergyGC(eSource, tSizeToReceive, false);
+                        if (tReceived > 0) {
                             tSizeToReceive -= tReceived;
+                            while (tSizeToReceive > 0) {
+                                tReceived = ((IEnergyHandlerGC) tTileEntity).receiveEnergyGC(eSource, tSizeToReceive, false);
+                                if (tReceived < 1) break;
+                                tSizeToReceive -= tReceived;
+                            }
+                            return 1;
                         }
-                        return 1;
                     }
                 }
+                return 0;
             }
-            return 0;
         }
 
         // IC2 Compat
@@ -398,8 +400,10 @@ public class GT_MetaPipeEntity_Cable extends MetaPipeEntity implements IMetaTile
         // ((tIsGregTechTileEntity && tIsTileEntityCable) && (tAlwaysLookConnected || tLetEnergyIn || tLetEnergyOut) ) --> Not needed
 
         // GC Compat
-        if (GregTech_API.mGalacticraft && tTileEntity instanceof IEnergyHandlerGC && (!(tTileEntity instanceof IConnector) || ((IConnector)tTileEntity).canConnect(tDir, NetworkType.POWER)))
-            return true;
+        if (GregTech_API.mGalacticraft) {
+            if (tTileEntity instanceof IEnergyHandlerGC && (!(tTileEntity instanceof IConnector) || ((IConnector) tTileEntity).canConnect(tDir, NetworkType.POWER)))
+                return true;
+        }
 
         // AE2-p2p Compat
         if (GT_Mod.gregtechproxy.mAE2Integration) {

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Item.java
@@ -1,7 +1,6 @@
 package gregtech.api.metatileentity.implementations;
 
 import gregtech.GT_Mod;
-import gregtech.api.GregTech_API;
 import gregtech.api.enums.*;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -11,6 +10,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.BaseMetaPipeEntity;
 import gregtech.api.metatileentity.MetaPipeEntity;
 import gregtech.api.objects.GT_RenderedTexture;
+import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Client;
 import net.minecraft.entity.Entity;
@@ -26,8 +26,6 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import static gregtech.api.enums.GT_Values.GT;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,7 +38,6 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     public int mTransferredItems = 0;
     public byte mLastReceivedFrom = 0, oLastReceivedFrom = 0;
     public boolean mIsRestrictive = false;
-    private boolean mCheckConnections = !GT_Mod.gregtechproxy.gt6Pipe;
 
     public GT_MetaPipeEntity_Item(int aID, String aName, String aNameRegional, float aThickNess, Materials aMaterial, int aInvSlotCount, int aStepSize, boolean aIsRestrictive, int aTickTime) {
         super(aID, aName, aNameRegional, aInvSlotCount, false);
@@ -157,8 +154,6 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     public void loadNBTData(NBTTagCompound aNBT) {
         mLastReceivedFrom = aNBT.getByte("mLastReceivedFrom");
         if (GT_Mod.gregtechproxy.gt6Pipe) {
-        	if (!aNBT.hasKey("mConnections"))
-        		mCheckConnections = true;
         	mConnections = aNBT.getByte("mConnections");
         }
     }
@@ -168,17 +163,7 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
         if (aBaseMetaTileEntity.isServerSide() && aTick % 10 == 0) {
             if (aTick % mTickTime == 0) mTransferredItems = 0;
 
-            for (byte tSide = 0; tSide < 6; tSide++) {
-            	ICoverable tBaseMetaTileEntity = aBaseMetaTileEntity.getTileEntityAtSide(tSide) instanceof ICoverable ? (ICoverable) aBaseMetaTileEntity.getTileEntityAtSide(tSide) : null;
-            	byte uSide = GT_Utility.getOppositeSide(tSide);
-                if ((mCheckConnections || isConnectedAtSide(tSide)
-                			|| aBaseMetaTileEntity.getCoverBehaviorAtSide(tSide).alwaysLookConnected(tSide, aBaseMetaTileEntity.getCoverIDAtSide(tSide), aBaseMetaTileEntity.getCoverDataAtSide(tSide), aBaseMetaTileEntity)
-                			|| (tBaseMetaTileEntity != null && tBaseMetaTileEntity.getCoverBehaviorAtSide(uSide).alwaysLookConnected(uSide, tBaseMetaTileEntity.getCoverIDAtSide(uSide), tBaseMetaTileEntity.getCoverDataAtSide(uSide), tBaseMetaTileEntity)))
-                		&& connect(tSide) == 0) {
-                	disconnect(tSide);
-                }
-            }
-            if (GT_Mod.gregtechproxy.gt6Pipe) mCheckConnections = false;
+            if (!GT_Mod.gregtechproxy.gt6Pipe || mCheckConnections) checkConnections();
 
             if (oLastReceivedFrom == mLastReceivedFrom) {
                 doTickProfilingInThisTick = false;
@@ -221,58 +206,48 @@ public class GT_MetaPipeEntity_Item extends MetaPipeEntity implements IMetaTileE
     }
 
 	@Override
-	public int connect(byte aSide) {
-		int rConnect = 0;
-		if (aSide >= 6) return rConnect;
-		TileEntity tTileEntity = getBaseMetaTileEntity().getTileEntityAtSide(aSide);
-		byte tSide = GT_Utility.getOppositeSide(aSide);
-        if (tTileEntity != null) {
-            boolean temp = GT_Utility.isConnectableNonInventoryPipe(tTileEntity, tSide);
-            if (tTileEntity instanceof IGregTechTileEntity) {
-                temp = true;
-                if (((IGregTechTileEntity) tTileEntity).getMetaTileEntity() == null) return rConnect;
-                if (getBaseMetaTileEntity().getColorization() >= 0) {
-                    byte tColor = ((IGregTechTileEntity) tTileEntity).getColorization();
-                    if (tColor >= 0 && tColor != getBaseMetaTileEntity().getColorization()) {
-                    	return rConnect;
-                    }
+    public boolean letsIn(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsItemsIn(aSide, aCoverID, aCoverVariable, -1, aTileEntity);
+    }
+
+    @Override
+    public boolean letsOut(GT_CoverBehavior coverBehavior, byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {
+        return coverBehavior.letsItemsOut(aSide, aCoverID, aCoverVariable, -1, aTileEntity);
                 }
-                if (((IGregTechTileEntity) tTileEntity).getMetaTileEntity().connectsToItemPipe(tSide)) {
-                	rConnect = 1;
+
+    @Override
+    public boolean canConnect(byte aSide, TileEntity tTileEntity) {
+        if (tTileEntity == null) return false;
+
+        final byte tSide = GT_Utility.getOppositeSide(aSide);
+        boolean connectable = GT_Utility.isConnectableNonInventoryPipe(tTileEntity, tSide);
+
+        final IGregTechTileEntity gTileEntity = (tTileEntity instanceof IGregTechTileEntity) ? (IGregTechTileEntity) tTileEntity : null;
+        if (gTileEntity != null) {
+            if (gTileEntity.getMetaTileEntity() == null) return false;
+            if (gTileEntity.getMetaTileEntity().connectsToItemPipe(tSide)) return true;
+            connectable = true;
                 }
-            }
-            if (rConnect == 0) {
+
             	if (tTileEntity instanceof IInventory) {
-                    temp = true;
-                    if (((IInventory) tTileEntity).getSizeInventory() <= 0) {
-                    	return rConnect;
-                    }
+            if (((IInventory) tTileEntity).getSizeInventory() <= 0) return false;
+            connectable = true;
                 }
                 if (tTileEntity instanceof ISidedInventory) {
-                    temp = true;
                     int[] tSlots = ((ISidedInventory) tTileEntity).getAccessibleSlotsFromSide(tSide);
-                    if (tSlots == null || tSlots.length <= 0) {
-                    	return rConnect;
-                    }
+            if (tSlots == null || tSlots.length <= 0) return false;
+            connectable = true;
                 }
-                if (temp) {
-                    if (getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsItemsIn(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), -1, getBaseMetaTileEntity())
-                    		|| getBaseMetaTileEntity().getCoverBehaviorAtSide(aSide).letsItemsOut(aSide, getBaseMetaTileEntity().getCoverIDAtSide(aSide), getBaseMetaTileEntity().getCoverDataAtSide(aSide), -1, getBaseMetaTileEntity())) {
-                    	rConnect = 1;
-                    }
-                }
-            }
-        }
-		if (rConnect == 0) {
-			if (!getBaseMetaTileEntity().getWorld().getChunkProvider().chunkExists(getBaseMetaTileEntity().getOffsetX(aSide, 1) >> 4, getBaseMetaTileEntity().getOffsetZ(aSide, 1) >> 4)) { // if chunk unloaded
-				rConnect = -1;
-			}
+
+        return connectable;
 		}
-        if (rConnect > 0) {
-        	super.connect(aSide);
+
+    @Override
+    public boolean getGT6StyleConnection() {
+        // Yes if GT6 pipes are enabled
+        return GT_Mod.gregtechproxy.gt6Pipe;
         }
-        return rConnect;
-	}
+
 
     @Override
     public boolean incrementTransferCounter(int aIncrement) {

--- a/src/main/java/gregtech/api/util/GT_Utility.java
+++ b/src/main/java/gregtech/api/util/GT_Utility.java
@@ -364,9 +364,11 @@ public class GT_Utility {
     public static boolean isConnectableNonInventoryPipe(Object aTileEntity, int aSide) {
         if (aTileEntity == null) return false;
         checkAvailabilities();
-        if (TE_CHECK) if (aTileEntity instanceof IItemDuct) return true;
-        if (BC_CHECK) if (aTileEntity instanceof buildcraft.api.transport.IPipeTile)
+        if (TE_CHECK && aTileEntity instanceof IItemDuct) return true;
+        if (BC_CHECK && aTileEntity instanceof buildcraft.api.transport.IPipeTile)
             return ((buildcraft.api.transport.IPipeTile) aTileEntity).isPipeConnected(ForgeDirection.getOrientation(aSide));
+        if (GregTech_API.mTranslocator && aTileEntity instanceof codechicken.translocator.TileItemTranslocator) return true;
+
         return false;
     }
     /**

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -210,6 +210,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     public boolean enableUBOres = true;
     public boolean gt6Pipe = true;
     public boolean gt6Cable = true;
+    public boolean ic2EnergySourceCompat = true;
     public boolean costlyCableConnection = false;
     public boolean mMoreComplicatedChemicalRecipes = false;
     

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -209,7 +209,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     public boolean enableGCOres = true;
     public boolean enableUBOres = true;
     public boolean gt6Pipe = true;
-    public boolean gt6Cable = false;
+    public boolean gt6Cable = true;
     public boolean costlyCableConnection = false;
     public boolean mMoreComplicatedChemicalRecipes = false;
     

--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -87,6 +87,13 @@ public class GT_Block_Machines
         }
     }
 
+    public void onNeighborBlockChange(World aWorld, int aX, int aY, int aZ, Block aBlock) {
+        TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
+        if ((tTileEntity instanceof BaseMetaPipeEntity)) {
+            ((BaseMetaPipeEntity) tTileEntity).onNeighborBlockChange(aX, aY, aZ);
+        }
+    }
+
     public void onBlockAdded(World aWorld, int aX, int aY, int aZ) {
         super.onBlockAdded(aWorld, aX, aY, aZ);
         if (GregTech_API.isMachineBlock(this, aWorld.getBlockMetadata(aX, aY, aZ))) {

--- a/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Item_Machines.java
@@ -158,8 +158,16 @@ public class GT_Item_Machines
                     tTileEntity.setOwnerName(aPlayer.getDisplayName());
                 }
                 tTileEntity.getMetaTileEntity().initDefaultModes(aStack.getTagCompound());
+                final byte aSide = GT_Utility.getOppositeSide(side);
                 if (tTileEntity.getMetaTileEntity() instanceof IConnectable) {
-                	((IConnectable) tTileEntity.getMetaTileEntity()).connect(GT_Utility.getOppositeSide(side));
+                    // If we're connectable, try connecting to whatever we're up against
+                	((IConnectable) tTileEntity.getMetaTileEntity()).connect(aSide);
+                } else if (aPlayer != null && aPlayer.isSneaking()) {
+                    // If we're being placed against something that is connectable, try telling it to connect to us
+                    IGregTechTileEntity aTileEntity = tTileEntity.getIGregTechTileEntityAtSide(aSide);
+                    if (aTileEntity != null && aTileEntity.getMetaTileEntity() instanceof IConnectable) {
+                        ((IConnectable) aTileEntity.getMetaTileEntity()).connect((byte)side);
+                    }
                 }
             }
         } else if (!aWorld.setBlock(aX, aY, aZ, this.field_150939_a, tDamage, 3)) {

--- a/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
+++ b/src/main/java/gregtech/common/covers/GT_Cover_Fluidfilter.java
@@ -8,8 +8,18 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.*;
 
 
-public class GT_Cover_Fluidfilter
-        extends GT_CoverBehavior {
+public class GT_Cover_Fluidfilter extends GT_CoverBehavior {
+
+    // Uses the lower 3 bits of the cover variable, so we have 8 options to work with (0-7)
+    private final int FILTER_INPUT_DENY_OUTPUT = 0;
+    private final int INVERT_INPUT_DENY_OUTPUT = 1;
+    private final int FILTER_INPUT_ANY_OUTPUT = 2;
+    private final int INVERT_INPUT_ANY_OUTPUT = 3;
+    private final int DENY_INPUT_FILTER_OUTPUT = 4;
+    private final int DENY_INPUT_INVERT_OUTPUT = 5;
+    private final int ANY_INPUT_FILTER_OUTPUT = 6;
+    private final int ANY_INPUT_INVERT_OUTPUT = 7;
+
             
     public int doCoverThings(byte aSide, byte aInputRedstone, int aCoverID, int aCoverVariable, ICoverable aTileEntity, long aTimer) {
         return aCoverVariable;
@@ -18,13 +28,19 @@ public class GT_Cover_Fluidfilter
     public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
         int aFilterMode = aCoverVariable & 7;
         aCoverVariable ^=aFilterMode;
-        aFilterMode = (aFilterMode + (aPlayer.isSneaking()? -1 : 1)) % 4;
-        if(aFilterMode < 0){aFilterMode = 3;}
+        aFilterMode = (aFilterMode + (aPlayer.isSneaking()? -1 : 1)) % 8;
+        if (aFilterMode < 0) {
+            aFilterMode = 7;
+        }
         switch(aFilterMode) {
-            case 0: GT_Utility.sendChatToPlayer(aPlayer, trans("043", "Allow input, no output")); break;
-            case 1: GT_Utility.sendChatToPlayer(aPlayer, trans("044", "Deny input, no output")); break;
-            case 2: GT_Utility.sendChatToPlayer(aPlayer, trans("045", "Allow input, permit any output")); break;
-            case 3: GT_Utility.sendChatToPlayer(aPlayer, trans("046", "Deny input, permit any output")); break;
+            case FILTER_INPUT_DENY_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("043", "Filter input, Deny output")); break;
+            case INVERT_INPUT_DENY_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("044", "Invert input, Deny output")); break;
+            case FILTER_INPUT_ANY_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("045", "Filter input, Permit any output")); break;
+            case INVERT_INPUT_ANY_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("046", "Invert input, Permit any output")); break;
+            case DENY_INPUT_FILTER_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("219", "Deny input, Filter output")); break;
+            case DENY_INPUT_INVERT_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("220", "Deny input, Invert output")); break;
+            case ANY_INPUT_FILTER_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("221", "Permit any input, Filter output")); break;
+            case ANY_INPUT_INVERT_OUTPUT: GT_Utility.sendChatToPlayer(aPlayer, trans("222", "Permit any input, Invert output")); break;
         }
         aCoverVariable|=aFilterMode;
         return aCoverVariable;
@@ -32,12 +48,18 @@ public class GT_Cover_Fluidfilter
     
     public boolean onCoverRightclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
        //System.out.println("rightclick");
-        if (((aX > 0.375D) && (aX < 0.625D)) || ((aSide > 3) && (((aY > 0.375D) && (aY < 0.625D)) || ((aSide < 2) && (((aZ > 0.375D) && (aZ < 0.625D)) || (aSide == 2) || (aSide == 3)))))) {
+        if (
+                ((aX > 0.375D) && (aX < 0.625D)) ||
+                ((aSide > 3) && ((aY > 0.375D) && (aY < 0.625D))) ||
+                ((aSide < 2) && ((aZ > 0.375D) && (aZ < 0.625D))) ||
+                (aSide == 2) ||
+                (aSide == 3)
+        ) {
             ItemStack tStack = aPlayer.inventory.getCurrentItem();
-            if(tStack!=null){
+            if (tStack == null) return true;
+
             FluidStack tFluid = FluidContainerRegistry.getFluidForFilledItem(tStack);
             if(tFluid!=null){
-                //System.out.println(tFluid.getLocalizedName()+" "+tFluid.getFluidID());
                 int aFluid = tFluid.getFluidID();
                 aCoverVariable = (aCoverVariable & 7) | (aFluid << 3);
                 aTileEntity.setCoverDataAtSide(aSide, aCoverVariable);
@@ -53,7 +75,6 @@ public class GT_Cover_Fluidfilter
                     GT_Utility.sendChatToPlayer(aPlayer, trans("047", "Filter Fluid: ") + sFluid.getLocalizedName());
                 }
             }
-            }
             return true;
         }
         return false;
@@ -61,16 +82,38 @@ public class GT_Cover_Fluidfilter
     
     @Override
     public boolean letsFluidIn(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
-        if(aFluid==null){return true;}
+        if (aFluid == null) return true;
+
         int aFilterMode = aCoverVariable & 7;
         int aFilterFluid = aCoverVariable >>> 3;
-        return aFluid.getID() == aFilterFluid ? aFilterMode == 0 || aFilterMode == 2 : aFilterMode == 1 || aFilterMode == 3;
+
+        if (aFilterMode == DENY_INPUT_FILTER_OUTPUT || aFilterMode == DENY_INPUT_INVERT_OUTPUT)
+            return false;
+        else if (aFilterMode == ANY_INPUT_FILTER_OUTPUT || aFilterMode == ANY_INPUT_INVERT_OUTPUT)
+            return true;
+        else if (aFluid.getID() == aFilterFluid)
+            return aFilterMode == FILTER_INPUT_DENY_OUTPUT || aFilterMode == FILTER_INPUT_ANY_OUTPUT;
+        else
+            return aFilterMode == INVERT_INPUT_DENY_OUTPUT || aFilterMode == INVERT_INPUT_ANY_OUTPUT;
+
     }
     
     @Override
     public boolean letsFluidOut(byte aSide, int aCoverID, int aCoverVariable, Fluid aFluid, ICoverable aTileEntity) {
+        if (aFluid == null) return true;
+
         int aFilterMode = aCoverVariable & 7;
-        return aFilterMode != 0 && aFilterMode != 1;
+        int aFilterFluid = aCoverVariable >>> 3;
+
+        if (aFilterMode == FILTER_INPUT_DENY_OUTPUT || aFilterMode == INVERT_INPUT_DENY_OUTPUT)
+            return false;
+        else if (aFilterMode == FILTER_INPUT_ANY_OUTPUT || aFilterMode == INVERT_INPUT_ANY_OUTPUT)
+            return true;
+        else if (aFluid.getID() == aFilterFluid)
+            return aFilterMode == DENY_INPUT_FILTER_OUTPUT || aFilterMode == ANY_INPUT_FILTER_OUTPUT;
+        else
+            return aFilterMode == DENY_INPUT_INVERT_OUTPUT || aFilterMode == ANY_INPUT_INVERT_OUTPUT;
+
     }
     
     public boolean alwaysLookConnected(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity) {


### PR DESCRIPTION
Changes from downstream (GTNH fork)


**Pipes/Cables - Player visible:**

* GT6 style cables changed default to on
* Shift Clicking while placing a GT machine will now try connecting to the cable/pipe it is placed on
* You can open a connection to the air for pipes & wires, allowing the next thing you place down to auto connect (ie: a JABBA barrel)
* Distribute Fluids - Modeled after several of the upstream PRs
* Fluid regulators on pipes should stop spazzing out now
* Fluid filter covers - Now work with filtering output
* Spray paint on wires/pipes/machines triggers a disconnection check
* Placing a block next to a wire/pipe triggers a disconnect check
* Shutters & machine control covers will no longer visibility disconnect the pipe/cable - but will continue to function at blocking the input/output

Backend changes:

* Unified connect() method for pipes/wires - each subclass has it's own canConnect(), letsIn(), and * letsOut() methods that map to the specifics for that implementation
* Rewrote the canConnect() logic to be more readable - should be roughly equivalent to the old logic


GC Energy Compat

* GT cables now properly fill GalacticCraft machines with Energy

IC2/AE2 Energy Compat

* Updated IC2 & AE2 energy compatibility
* Added an option ic2EnergySourceCompat (default is on) to allow GT cables to pull energy directly from IC2 energy sources (nuclear reactors, MSFUs, etc) without the need for a transformer
* Filling IC2/AE2 energy buffers will now send multiple amps if needed

Misc

* Use a set instead of an arraylist for transfer electricity; deprecated backwards compatible method left in
