### PR TITLE
fix(blockmachines): persistency on harvest

### DIFF
--- a/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
+++ b/src/main/java/gregtech/common/blocks/GT_Block_Machines.java
@@ -365,6 +365,22 @@ public class GT_Block_Machines
         return mTemporaryTileEntity.get() == null ? new ArrayList() : ((IGregTechTileEntity) mTemporaryTileEntity.get()).getDrops();
     }
 
+    @Override
+    public boolean removedByPlayer(World aWorld, EntityPlayer aPlayer, int aX, int aY, int aZ, boolean aWillHarvest) {
+        if (aWillHarvest) {
+            return true; // This delays deletion of the block until after getDrops
+        } else {
+            return super.removedByPlayer(aWorld, aPlayer, aX, aY, aZ, false);
+        }
+    }
+
+    @Override
+    public void harvestBlock(World aWorld, EntityPlayer aPlayer, int aX, int aY, int aZ, int aMeta)
+    {
+        super.harvestBlock(aWorld, aPlayer, aX, aY, aZ, aMeta);
+        aWorld.setBlockToAir(aX, aY, aZ);
+    }
+
     public int getComparatorInputOverride(World aWorld, int aX, int aY, int aZ, int aSide) {
         TileEntity tTileEntity = aWorld.getTileEntity(aX, aY, aZ);
         if (((tTileEntity instanceof IGregTechTileEntity))) {


### PR DESCRIPTION
This patch fixes persistency of NBT tags in machine item when machine block is harvested.

Machines with an `@Override` on `setItemNBT` will now persist data correctly when harvested.

Change fixes intended persistency behaviour of following machines:
- Item buffers will persist screwdriver configured output stack size when harvested.
- Item distributors will persist setings of items per face.

@draknyte1 will certainly help you with portable tanks