### PR TITLE
fix(rendering): UV Mapping on tiles

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Buffer.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Buffer.java
@@ -8,10 +8,18 @@ import gregtech.api.util.GT_Utility;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import static gregtech.api.enums.GT_Values.V;
 
 public abstract class GT_MetaTileEntity_Buffer extends GT_MetaTileEntity_TieredMachineBlock {
+    private static final int OUTPUT_INDEX = 0;
+    private static final int ARROW_RIGHT_INDEX = 1;
+    private static final int ARROW_DOWN_INDEX = 2;
+    private static final int ARROW_LEFT_INDEX = 3;
+    private static final int ARROW_UP_INDEX = 4;
+    private static final int FRONT_INDEX = 5;
+
     public boolean bOutput = false, bRedstoneIfFull = false, bInvert = false;
     public int mSuccess = 0, mTargetStackSize = 0;
 
@@ -25,74 +33,85 @@ public abstract class GT_MetaTileEntity_Buffer extends GT_MetaTileEntity_TieredM
 
     @Override
     public ITexture[][][] getTextureSet(ITexture[] aTextures) {
-        ITexture[][][] rTextures = new ITexture[6][17][];
-        ITexture tIcon = getOverlayIcon(), tOut = new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_PIPE_OUT), tUp = new GT_RenderedTexture(Textures.BlockIcons.ARROW_UP), tDown = new GT_RenderedTexture(Textures.BlockIcons.ARROW_DOWN), tLeft = new GT_RenderedTexture(Textures.BlockIcons.ARROW_LEFT), tRight = new GT_RenderedTexture(Textures.BlockIcons.ARROW_RIGHT);
-        for (byte i = -1; i < 16; i++) {
-            rTextures[0][i + 1] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i + 1], tOut};
-            rTextures[1][i + 1] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i + 1], tRight, tIcon};
-            rTextures[2][i + 1] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i + 1], tDown, tIcon};
-            rTextures[3][i + 1] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i + 1], tLeft, tIcon};
-            rTextures[4][i + 1] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i + 1], tUp, tIcon};
-            rTextures[5][i + 1] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i + 1], tIcon};
+        ITexture[][][] rTextures = new ITexture[ForgeDirection.VALID_DIRECTIONS.length][17][];
+        ITexture tIcon = getOverlayIcon();
+        ITexture tOut = new GT_RenderedTexture(Textures.BlockIcons.OVERLAY_PIPE_OUT);
+        ITexture tUp = new GT_RenderedTexture(Textures.BlockIcons.ARROW_UP);
+        ITexture tDown = new GT_RenderedTexture(Textures.BlockIcons.ARROW_DOWN);
+        ITexture tLeft = new GT_RenderedTexture(Textures.BlockIcons.ARROW_LEFT);
+        ITexture tRight = new GT_RenderedTexture(Textures.BlockIcons.ARROW_RIGHT);
+        for (int i = 0; i < rTextures[0].length; i++) {
+            rTextures[OUTPUT_INDEX][i] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i], tOut};
+            rTextures[ARROW_RIGHT_INDEX][i] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i], tRight, tIcon};
+            rTextures[ARROW_DOWN_INDEX][i] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i], tDown, tIcon};
+            rTextures[ARROW_LEFT_INDEX][i] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i], tLeft, tIcon};
+            rTextures[ARROW_UP_INDEX][i] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i], tUp, tIcon};
+            rTextures[FRONT_INDEX][i] = new ITexture[]{Textures.BlockIcons.MACHINE_CASINGS[mTier][i], tIcon};
         }
         return rTextures;
     }
 
     @Override
     public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex, boolean aActive, boolean aRedstone) {
-        if (aSide == aFacing) return mTextures[5][aColorIndex + 1];
-        if (GT_Utility.getOppositeSide(aSide) == aFacing) return mTextures[0][aColorIndex + 1];
-        switch (aFacing) {
-            case 0:
-                return mTextures[4][aColorIndex + 1];
-            case 1:
-                return mTextures[2][aColorIndex + 1];
-            case 2:
-                switch (aSide) {
-                    case 0:
-                        return mTextures[2][aColorIndex + 1];
-                    case 1:
-                        return mTextures[2][aColorIndex + 1];
-                    case 4:
-                        return mTextures[1][aColorIndex + 1];
-                    case 5:
-                        return mTextures[3][aColorIndex + 1];
+        int colorIndex = aColorIndex + 1;
+        ForgeDirection side = ForgeDirection.VALID_DIRECTIONS[aSide];
+        ForgeDirection facing = ForgeDirection.VALID_DIRECTIONS[aFacing];
+        if (side == facing) return mTextures[FRONT_INDEX][colorIndex];
+        if (ForgeDirection.OPPOSITES[aSide] == aFacing) return mTextures[OUTPUT_INDEX][colorIndex];
+        switch (facing) {
+            case DOWN:
+                return mTextures[ARROW_UP_INDEX][colorIndex]; // ARROW_UP
+            case UP:
+                return mTextures[ARROW_DOWN_INDEX][colorIndex]; // ARROW_DOWN
+            case NORTH:
+                switch (side) {
+                    case DOWN:
+                    case UP:
+                        return mTextures[ARROW_DOWN_INDEX][colorIndex]; // ARROW_DOWN
+                    case WEST:
+                        return mTextures[ARROW_RIGHT_INDEX][colorIndex]; // ARROW_RIGHT
+                    case EAST:
+                        return mTextures[ARROW_LEFT_INDEX][colorIndex]; // ARROW_LEFT
+                    default:
                 }
-            case 3:
-                switch (aSide) {
-                    case 0:
-                        return mTextures[4][aColorIndex + 1];
-                    case 1:
-                        return mTextures[4][aColorIndex + 1];
-                    case 4:
-                        return mTextures[3][aColorIndex + 1];
-                    case 5:
-                        return mTextures[1][aColorIndex + 1];
+                break;
+            case SOUTH:
+                switch (side) {
+                    case DOWN:
+                    case UP:
+                        return mTextures[ARROW_UP_INDEX][colorIndex]; // ARROW_UP
+                    case WEST:
+                        return mTextures[ARROW_LEFT_INDEX][colorIndex]; // ARROW_LEFT
+                    case EAST:
+                        return mTextures[ARROW_RIGHT_INDEX][colorIndex]; // ARROW_RIGHT
+                    default:
                 }
-            case 4:
-                switch (aSide) {
-                    case 0:
-                        return mTextures[3][aColorIndex + 1];
-                    case 1:
-                        return mTextures[1][aColorIndex + 1];
-                    case 2:
-                        return mTextures[3][aColorIndex + 1];
-                    case 3:
-                        return mTextures[1][aColorIndex + 1];
+                break;
+            case WEST:
+                switch (side) {
+                    case DOWN:
+                    case UP:
+                    case SOUTH:
+                        return mTextures[ARROW_RIGHT_INDEX][colorIndex]; // ARROW_RIGHT
+                    case NORTH:
+                        return mTextures[ARROW_LEFT_INDEX][colorIndex]; // ARROW_LEFT
+                    default:
                 }
-            case 5:
-                switch (aSide) {
-                    case 0:
-                        return mTextures[1][aColorIndex + 1];
-                    case 1:
-                        return mTextures[3][aColorIndex + 1];
-                    case 2:
-                        return mTextures[1][aColorIndex + 1];
-                    case 3:
-                        return mTextures[3][aColorIndex + 1];
+                break;
+            case EAST:
+                switch (side) {
+                    case DOWN:
+                    case UP:
+                    case SOUTH:
+                        return mTextures[ARROW_LEFT_INDEX][colorIndex]; // ARROW_LEFT
+                    case NORTH:
+                        return mTextures[ARROW_RIGHT_INDEX][colorIndex]; // ARROW_RIGHT
+                    default:
                 }
+                break;
+            default:
         }
-        return mTextures[5][aColorIndex + 1];
+        return mTextures[FRONT_INDEX][colorIndex];
     }
 
     @Override

--- a/src/main/java/gregtech/api/objects/GT_RenderedTexture.java
+++ b/src/main/java/gregtech/api/objects/GT_RenderedTexture.java
@@ -37,94 +37,124 @@ public class GT_RenderedTexture implements ITexture, IColorModulationContainer {
 
     @Override
     public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tesselator = Tessellator.instance;
+        tesselator.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        aRenderer.field_152631_f = true;
         aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(153, 153, 153, 255);
+            tesselator.setColorRGBA(153, 153, 153, 255);
             aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
+        aRenderer.field_152631_f = false;
     }
+
 
     @Override
     public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tesselator = Tessellator.instance;
+        tesselator.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
         aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(153, 153, 153, 255);
+            tesselator.setColorRGBA(153, 153, 153, 255);
             aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
     }
 
     @Override
     public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 1.0F), (int) (mRGBa[1] * 1.0F), (int) (mRGBa[2] * 1.0F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tesselator = Tessellator.instance;
+        tesselator.setColorRGBA((int) (mRGBa[0] * 1.0F), (int) (mRGBa[1] * 1.0F), (int) (mRGBa[2] * 1.0F), mAllowAlpha ? 255 - mRGBa[3] : 255);
         aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(255, 255, 255, 255);
+            tesselator.setColorRGBA(255, 255, 255, 255);
             aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
     }
 
     @Override
     public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.5F), (int) (mRGBa[1] * 0.5F), (int) (mRGBa[2] * 0.5F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setColorRGBA((int) (mRGBa[0] * 0.5F), (int) (mRGBa[1] * 0.5F), (int) (mRGBa[2] * 0.5F), mAllowAlpha ? 255 - mRGBa[3] : 255);
         IIcon aIcon = mIconContainer.getIcon();
 
-        float d_16 = 16.0F;
-        float d3 = (float)aIcon.getInterpolatedU(aRenderer.renderMaxX * d_16);
-        float d4 = (float)aIcon.getInterpolatedU(aRenderer.renderMinX * d_16);
-        float d5 = (float)aIcon.getInterpolatedV(aRenderer.renderMinZ * d_16);
-        float d6 = (float)aIcon.getInterpolatedV(aRenderer.renderMaxZ * d_16);
+        float minU = aIcon.getInterpolatedU((1.0D - aRenderer.renderMaxX) * 16.0D);
+        float maxU = aIcon.getInterpolatedU((1.0D - aRenderer.renderMinX) * 16.0D);
+        float minV = aIcon.getInterpolatedV(aRenderer.renderMinZ * 16.0D);
+        float maxV = aIcon.getInterpolatedV(aRenderer.renderMaxZ * 16.0D);
 
         if (aRenderer.renderMinX < 0.0D || aRenderer.renderMaxX > 1.0D) {
-            d3 = aIcon.getMaxU();
-            d4 = aIcon.getMinU();
+            minU = 16.0F - aIcon.getMaxU();
+            maxU = 16.0F - aIcon.getMinU();
         }
 
         if (aRenderer.renderMinZ < 0.0D || aRenderer.renderMaxZ > 1.0D) {
-            d5 = aIcon.getMinV();
-            d6 = aIcon.getMaxV();
+            minV = aIcon.getMinV();
+            maxV = aIcon.getMaxV();
         }
 
-        float d11 = aX + (float)aRenderer.renderMinX;
-        float d12 = aX + (float)aRenderer.renderMaxX;
-        float d13 = aY + (float)aRenderer.renderMinY;
-        float d14 = aZ + (float)aRenderer.renderMinZ;
-        float d15 = aZ + (float)aRenderer.renderMaxZ;
+        double minX = aX + aRenderer.renderMinX;
+        double maxX = aX + aRenderer.renderMaxX;
+        double minY = aY + aRenderer.renderMinY;
+        double minZ = aZ + aRenderer.renderMinZ;
+        double maxZ = aZ + aRenderer.renderMaxZ;
 
-        Tessellator.instance.addVertexWithUV((double)d11, (double)d13, (double)d15, (double)d3, (double)d6);
-        Tessellator.instance.addVertexWithUV((double)d11, (double)d13, (double)d14, (double)d3, (double)d5);
-        Tessellator.instance.addVertexWithUV((double)d12, (double)d13, (double)d14, (double)d4, (double)d5);
-        Tessellator.instance.addVertexWithUV((double)d12, (double)d13, (double)d15, (double)d4, (double)d6);
+        tessellator.addVertexWithUV(minX, minY, maxZ, maxU, maxV);
+        tessellator.addVertexWithUV(minX, minY, minZ, maxU, minV);
+        tessellator.addVertexWithUV(maxX, minY, minZ, minU, minV);
+        tessellator.addVertexWithUV(maxX, minY, maxZ, minU, maxV);
+        if (mIconContainer.getOverlayIcon() != null) {
+            tessellator.setColorRGBA(128, 128, 128, 255);
 
-        if ((aIcon = mIconContainer.getOverlayIcon()) != null) {
-            Tessellator.instance.setColorRGBA(128, 128, 128, 255);
+            minU = aIcon.getInterpolatedU((1.0D - aRenderer.renderMaxX) * 16.0D);
+            maxU = aIcon.getInterpolatedU((1.0D - aRenderer.renderMinX) * 16.0D);
+            minV = aIcon.getInterpolatedV(aRenderer.renderMinZ * 16.0D);
+            maxV = aIcon.getInterpolatedV(aRenderer.renderMaxZ * 16.0D);
 
-            Tessellator.instance.addVertexWithUV((double)d11, (double)d13, (double)d15, (double)d3, (double)d6);
-            Tessellator.instance.addVertexWithUV((double)d11, (double)d13, (double)d14, (double)d3, (double)d5);
-            Tessellator.instance.addVertexWithUV((double)d12, (double)d13, (double)d14, (double)d4, (double)d5);
-            Tessellator.instance.addVertexWithUV((double)d12, (double)d13, (double)d15, (double)d4, (double)d6);
+            if (aRenderer.renderMinX < 0.0D || aRenderer.renderMaxX > 1.0D) {
+                minU = 16.0F - aIcon.getMaxU();
+                maxU = 16.0F - aIcon.getMinU();
+            }
+
+            if (aRenderer.renderMinZ < 0.0D || aRenderer.renderMaxZ > 1.0D) {
+                minV = aIcon.getMinV();
+                maxV = aIcon.getMaxV();
+            }
+
+            minX = aX + (float)aRenderer.renderMinX;
+            maxX = aX + (float)aRenderer.renderMaxX;
+            minY = aY + (float)aRenderer.renderMinY;
+            minZ = aZ + (float)aRenderer.renderMinZ;
+            maxZ = aZ + (float)aRenderer.renderMaxZ;
+
+            tessellator.addVertexWithUV(minX, minY, maxZ, maxU, maxV);
+            tessellator.addVertexWithUV(minX, minY, minZ, maxU, minV);
+            tessellator.addVertexWithUV(maxX, minY, minZ, minU, minV);
+            tessellator.addVertexWithUV(maxX, minY, maxZ, minU, maxV);
         }
     }
 
     @Override
     public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tesselator = Tessellator.instance;
+        tesselator.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
         aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(204, 204, 204, 255);
+            tesselator.setColorRGBA(204, 204, 204, 255);
             aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
     }
 
     @Override
     public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        final Tessellator tesselator = Tessellator.instance;
+        tesselator.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        aRenderer.field_152631_f = true;
         aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, mIconContainer.getIcon());
         if (mIconContainer.getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(204, 204, 204, 255);
+            tesselator.setColorRGBA(204, 204, 204, 255);
             aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
         }
+        aRenderer.field_152631_f = false;
     }
 
     @Override

--- a/src/main/java/gregtech/api/objects/GT_SidedTexture.java
+++ b/src/main/java/gregtech/api/objects/GT_SidedTexture.java
@@ -6,12 +6,9 @@ import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.util.IIcon;
 
 public class GT_SidedTexture implements ITexture, IColorModulationContainer {
-    private final IIconContainer[] mIconContainer;
-    private final boolean mAllowAlpha;
+    private final ITexture[] mTextures;
     /**
      * DO NOT MANIPULATE THE VALUES INSIDE THIS ARRAY!!!
      * <p/>
@@ -22,8 +19,14 @@ public class GT_SidedTexture implements ITexture, IColorModulationContainer {
 
     public GT_SidedTexture(IIconContainer aIcon0, IIconContainer aIcon1, IIconContainer aIcon2, IIconContainer aIcon3, IIconContainer aIcon4, IIconContainer aIcon5, short[] aRGBa, boolean aAllowAlpha) {
         if (aRGBa.length != 4) throw new IllegalArgumentException("RGBa doesn't have 4 Values @ GT_RenderedTexture");
-        mIconContainer = new IIconContainer[]{aIcon0, aIcon1, aIcon2, aIcon3, aIcon4, aIcon5};
-        mAllowAlpha = aAllowAlpha;
+        mTextures = new ITexture[]{
+                new GT_RenderedTexture(aIcon0, aRGBa, aAllowAlpha),
+                new GT_RenderedTexture(aIcon1, aRGBa, aAllowAlpha),
+                new GT_RenderedTexture(aIcon2, aRGBa, aAllowAlpha),
+                new GT_RenderedTexture(aIcon3, aRGBa, aAllowAlpha),
+                new GT_RenderedTexture(aIcon4, aRGBa, aAllowAlpha),
+                new GT_RenderedTexture(aIcon5, aRGBa, aAllowAlpha)
+        };
         mRGBa = aRGBa;
     }
 
@@ -45,115 +48,32 @@ public class GT_SidedTexture implements ITexture, IColorModulationContainer {
 
     @Override
     public void renderXPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, mIconContainer[5].getIcon());
-        if (mIconContainer[5].getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(153, 153, 153, 255);
-            aRenderer.renderFaceXPos(aBlock, aX, aY, aZ, mIconContainer[5].getOverlayIcon());
-        }
+        mTextures[5].renderXPos(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderXNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.6F), (int) (mRGBa[1] * 0.6F), (int) (mRGBa[2] * 0.6F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, mIconContainer[4].getIcon());
-        if (mIconContainer[4].getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(153, 153, 153, 255);
-            aRenderer.renderFaceXNeg(aBlock, aX, aY, aZ, mIconContainer[4].getOverlayIcon());
-        }
+        mTextures[4].renderXNeg(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderYPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 1.0F), (int) (mRGBa[1] * 1.0F), (int) (mRGBa[2] * 1.0F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, mIconContainer[1].getIcon());
-        if (mIconContainer[1].getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(255, 255, 255, 255);
-            aRenderer.renderFaceYPos(aBlock, aX, aY, aZ, mIconContainer[1].getOverlayIcon());
-        }
+        mTextures[1].renderYPos(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.5F), (int) (mRGBa[1] * 0.5F), (int) (mRGBa[2] * 0.5F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        IIcon aIcon = mIconContainer[0].getIcon();
-
-        float d_16 = 16.0F;
-        float d3 = (float)aIcon.getInterpolatedU(aRenderer.renderMaxX * d_16);
-        float d4 = (float)aIcon.getInterpolatedU(aRenderer.renderMinX * d_16);
-        float d5 = (float)aIcon.getInterpolatedV(aRenderer.renderMinZ * d_16);
-        float d6 = (float)aIcon.getInterpolatedV(aRenderer.renderMaxZ * d_16);
-
-        if (aRenderer.renderMinX < 0.0D || aRenderer.renderMaxX > 1.0D) {
-            d3 = aIcon.getMaxU();
-            d4 = aIcon.getMinU();
-        }
-
-        if (aRenderer.renderMinZ < 0.0D || aRenderer.renderMaxZ > 1.0D) {
-            d5 = aIcon.getMinV();
-            d6 = aIcon.getMaxV();
-        }
-
-        float d11 = aX + (float)aRenderer.renderMinX;
-        float d12 = aX + (float)aRenderer.renderMaxX;
-        float d13 = aY + (float)aRenderer.renderMinY;
-        float d14 = aZ + (float)aRenderer.renderMinZ;
-        float d15 = aZ + (float)aRenderer.renderMaxZ;
-
-        Tessellator.instance.addVertexWithUV((double)d11, (double)d13, (double)d15, (double)d3, (double)d6);
-        Tessellator.instance.addVertexWithUV((double)d11, (double)d13, (double)d14, (double)d3, (double)d5);
-        Tessellator.instance.addVertexWithUV((double)d12, (double)d13, (double)d14, (double)d4, (double)d5);
-        Tessellator.instance.addVertexWithUV((double)d12, (double)d13, (double)d15, (double)d4, (double)d6);
-
-        if ((aIcon = mIconContainer[0].getOverlayIcon()) != null) {
-            Tessellator.instance.setColorRGBA(128, 128, 128, 255);
-
-            d3 = (float)aIcon.getInterpolatedU(aRenderer.renderMaxX * d_16);
-            d4 = (float)aIcon.getInterpolatedU(aRenderer.renderMinX * d_16);
-            d5 = (float)aIcon.getInterpolatedV(aRenderer.renderMinZ * d_16);
-            d6 = (float)aIcon.getInterpolatedV(aRenderer.renderMaxZ * d_16);
-
-            if (aRenderer.renderMinX < 0.0D || aRenderer.renderMaxX > 1.0D) {
-                d3 = aIcon.getMaxU();
-                d4 = aIcon.getMinU();
-            }
-
-            if (aRenderer.renderMinZ < 0.0D || aRenderer.renderMaxZ > 1.0D) {
-                d5 = aIcon.getMinV();
-                d6 = aIcon.getMaxV();
-            }
-
-            d11 = aX + (float)aRenderer.renderMinX;
-            d12 = aX + (float)aRenderer.renderMaxX;
-            d13 = aY + (float)aRenderer.renderMinY;
-            d14 = aZ + (float)aRenderer.renderMinZ;
-            d15 = aZ + (float)aRenderer.renderMaxZ;
-
-            Tessellator.instance.addVertexWithUV((double)d11, (double)d13, (double)d15, (double)d3, (double)d6);
-            Tessellator.instance.addVertexWithUV((double)d11, (double)d13, (double)d14, (double)d3, (double)d5);
-            Tessellator.instance.addVertexWithUV((double)d12, (double)d13, (double)d14, (double)d4, (double)d5);
-            Tessellator.instance.addVertexWithUV((double)d12, (double)d13, (double)d15, (double)d4, (double)d6);
-        }
+        mTextures[0].renderYNeg(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderZPos(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, mIconContainer[3].getIcon());
-        if (mIconContainer[3].getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(204, 204, 204, 255);
-            aRenderer.renderFaceZPos(aBlock, aX, aY, aZ, mIconContainer[3].getOverlayIcon());
-        }
+        mTextures[3].renderZPos(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
     public void renderZNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
-        Tessellator.instance.setColorRGBA((int) (mRGBa[0] * 0.8F), (int) (mRGBa[1] * 0.8F), (int) (mRGBa[2] * 0.8F), mAllowAlpha ? 255 - mRGBa[3] : 255);
-        aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, mIconContainer[2].getIcon());
-        if (mIconContainer[2].getOverlayIcon() != null) {
-            Tessellator.instance.setColorRGBA(204, 204, 204, 255);
-            aRenderer.renderFaceZNeg(aBlock, aX, aY, aZ, mIconContainer[2].getOverlayIcon());
-        }
+        mTextures[2].renderZNeg(aRenderer, aBlock, aX ,aY, aZ);
     }
 
     @Override
@@ -163,6 +83,9 @@ public class GT_SidedTexture implements ITexture, IColorModulationContainer {
 
     @Override
     public boolean isValidTexture() {
-        return mIconContainer != null && mIconContainer[0] != null && mIconContainer[1] != null && mIconContainer[2] != null && mIconContainer[3] != null && mIconContainer[4] != null && mIconContainer[5] != null;
+        for (ITexture renderedTexture : mTextures) {
+            if (!renderedTexture.isValidTexture()) return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/gregtech/api/objects/GT_StdRenderedTexture.java
+++ b/src/main/java/gregtech/api/objects/GT_StdRenderedTexture.java
@@ -1,0 +1,41 @@
+package gregtech.api.objects;
+
+import gregtech.api.enums.Dyes;
+import gregtech.api.interfaces.IIconContainer;
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
+
+/**
+ * This ITexture implementation extends the GT_RenderedTexture class
+ * to render with bottom side flipped as with dumb blocks rendering.
+ * It is used in Ore blocks rendering so they better blends with dumb block ores
+ * from vanilla or other mods, when seen from bottom.
+ */
+public class GT_StdRenderedTexture extends GT_RenderedTexture{
+
+    @SuppressWarnings("unused")
+    public GT_StdRenderedTexture(IIconContainer aIcon, short[] aRGBa, boolean aAllowAlpha) {
+        super(aIcon, aRGBa, aAllowAlpha);
+    }
+
+    public GT_StdRenderedTexture(IIconContainer aIcon, short[] aRGBa) {
+        super(aIcon, aRGBa, true);
+    }
+
+    @SuppressWarnings("unused")
+    public GT_StdRenderedTexture(IIconContainer aIcon) {
+        super(aIcon, Dyes._NULL.mRGBa);
+    }
+
+    @Override
+    public void renderYNeg(RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ) {
+        final Tessellator tessellator = Tessellator.instance;
+        tessellator.setColorRGBA((int) (mRGBa[0] * 0.5F), (int) (mRGBa[1] * 0.5F), (int) (mRGBa[2] * 0.5F), mAllowAlpha ? 255 - mRGBa[3] : 255);
+        aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, mIconContainer.getIcon());
+        if (mIconContainer.getOverlayIcon() != null) {
+            tessellator.setColorRGBA(128, 128, 128, 255);
+            aRenderer.renderFaceYNeg(aBlock, aX, aY, aZ, mIconContainer.getOverlayIcon());
+        }
+    }
+}

--- a/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
+++ b/src/main/java/gregtech/common/blocks/GT_TileEntity_Ores.java
@@ -8,6 +8,7 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.tileentity.ITexturedTileEntity;
 import gregtech.api.objects.GT_CopiedBlockTexture;
+import gregtech.api.objects.GT_StdRenderedTexture;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.objects.XSTR;
 import gregtech.api.util.GT_OreDictUnificator;
@@ -272,7 +273,7 @@ public class GT_TileEntity_Ores extends TileEntity implements ITexturedTileEntit
     public ITexture[] getTexture(Block aBlock, byte aSide) {
         Materials aMaterial = GregTech_API.sGeneratedMaterials[(this.mMetaData % 1000)];
         if ((aMaterial != null) && (this.mMetaData < 32000)) {
-            GT_RenderedTexture aIconSet = new GT_RenderedTexture(aMaterial.mIconSet.mTextures[this.mMetaData / 16000 == 0 ? OrePrefixes.ore.mTextureIndex : OrePrefixes.oreSmall.mTextureIndex], aMaterial.mRGBa);
+            GT_RenderedTexture aIconSet = new GT_StdRenderedTexture(aMaterial.mIconSet.mTextures[this.mMetaData / 16000 == 0 ? OrePrefixes.ore.mTextureIndex : OrePrefixes.oreSmall.mTextureIndex], aMaterial.mRGBa);
             if (aBlock instanceof GT_Block_Ores_Abstract) {
                 return new ITexture[]{((GT_Block_Ores_Abstract) aBlock).getTextureSet()[((this.mMetaData / 1000) % 16)], aIconSet};
             }

--- a/src/main/java/gregtech/common/render/GT_Renderer_Block.java
+++ b/src/main/java/gregtech/common/render/GT_Renderer_Block.java
@@ -154,7 +154,7 @@ public class GT_Renderer_Block
         }
         boolean[] tIsCovered = new boolean[6];
         for (byte i = 0; i < 6; i = (byte) (i + 1)) {
-            tIsCovered[i] = (aTileEntity.getCoverIDAtSide(i) != 0 ? true : false);
+            tIsCovered[i] = (aTileEntity.getCoverIDAtSide(i) != 0);
         }
         if ((tIsCovered[0]) && (tIsCovered[1]) && (tIsCovered[2]) && (tIsCovered[3]) && (tIsCovered[4]) && (tIsCovered[5])) {
             return renderStandardBlock(aWorld, aX, aY, aZ, aBlock, aRenderer);
@@ -426,14 +426,14 @@ public class GT_Renderer_Block
             }
             Tessellator.instance.setBrightness(aBlock.getMixedBrightnessForBlock(aWorld, aX, aFullBlock ? aY - 1 : aY, aZ));
         }
+
         if (aIcon != null) {
-            for (int i = 0; i < aIcon.length; i++) {
-                if (aIcon[i] != null) {
-                    aIcon[i].renderYNeg(aRenderer, aBlock, aX, aY, aZ);
+            for (ITexture iTexture : aIcon) {
+                if (iTexture != null) {
+                    iTexture.renderYNeg(aRenderer, aBlock, aX, aY, aZ);
                 }
             }
         }
-        aRenderer.flipTexture = false;
     }
 
     public static void renderPositiveYFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock) {
@@ -444,13 +444,12 @@ public class GT_Renderer_Block
             Tessellator.instance.setBrightness(aBlock.getMixedBrightnessForBlock(aWorld, aX, aFullBlock ? aY + 1 : aY, aZ));
         }
         if (aIcon != null) {
-            for (int i = 0; i < aIcon.length; i++) {
-                if (aIcon[i] != null) {
-                    aIcon[i].renderYPos(aRenderer, aBlock, aX, aY, aZ);
+            for (ITexture iTexture : aIcon) {
+                if (iTexture != null) {
+                    iTexture.renderYPos(aRenderer, aBlock, aX, aY, aZ);
                 }
             }
         }
-        aRenderer.flipTexture = false;
     }
 
     public static void renderNegativeZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock) {
@@ -460,15 +459,13 @@ public class GT_Renderer_Block
             }
             Tessellator.instance.setBrightness(aBlock.getMixedBrightnessForBlock(aWorld, aX, aY, aFullBlock ? aZ - 1 : aZ));
         }
-        aRenderer.flipTexture = (!aFullBlock);
         if (aIcon != null) {
-            for (int i = 0; i < aIcon.length; i++) {
-                if (aIcon[i] != null) {
-                    aIcon[i].renderZNeg(aRenderer, aBlock, aX, aY, aZ);
+            for (ITexture iTexture : aIcon) {
+                if (iTexture != null) {
+                    iTexture.renderZNeg(aRenderer, aBlock, aX, aY, aZ);
                 }
             }
         }
-        aRenderer.flipTexture = false;
     }
 
     public static void renderPositiveZFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock) {
@@ -479,13 +476,12 @@ public class GT_Renderer_Block
             Tessellator.instance.setBrightness(aBlock.getMixedBrightnessForBlock(aWorld, aX, aY, aFullBlock ? aZ + 1 : aZ));
         }
         if (aIcon != null) {
-            for (int i = 0; i < aIcon.length; i++) {
-                if (aIcon[i] != null) {
-                    aIcon[i].renderZPos(aRenderer, aBlock, aX, aY, aZ);
+            for (ITexture iTexture : aIcon) {
+                if (iTexture != null) {
+                    iTexture.renderZPos(aRenderer, aBlock, aX, aY, aZ);
                 }
             }
         }
-        aRenderer.flipTexture = false;
     }
 
     public static void renderNegativeXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock) {
@@ -496,13 +492,12 @@ public class GT_Renderer_Block
             Tessellator.instance.setBrightness(aBlock.getMixedBrightnessForBlock(aWorld, aFullBlock ? aX - 1 : aX, aY, aZ));
         }
         if (aIcon != null) {
-            for (int i = 0; i < aIcon.length; i++) {
-                if (aIcon[i] != null) {
-                    aIcon[i].renderXNeg(aRenderer, aBlock, aX, aY, aZ);
+            for (ITexture iTexture : aIcon) {
+                if (iTexture != null) {
+                    iTexture.renderXNeg(aRenderer, aBlock, aX, aY, aZ);
                 }
             }
         }
-        aRenderer.flipTexture = false;
     }
 
     public static void renderPositiveXFacing(IBlockAccess aWorld, RenderBlocks aRenderer, Block aBlock, int aX, int aY, int aZ, ITexture[] aIcon, boolean aFullBlock) {
@@ -512,15 +507,13 @@ public class GT_Renderer_Block
             }
             Tessellator.instance.setBrightness(aBlock.getMixedBrightnessForBlock(aWorld, aFullBlock ? aX + 1 : aX, aY, aZ));
         }
-        aRenderer.flipTexture = (!aFullBlock);
         if (aIcon != null) {
-            for (int i = 0; i < aIcon.length; i++) {
-                if (aIcon[i] != null) {
-                    aIcon[i].renderXPos(aRenderer, aBlock, aX, aY, aZ);
+            for (ITexture iTexture : aIcon) {
+                if (iTexture != null) {
+                    iTexture.renderXPos(aRenderer, aBlock, aX, aY, aZ);
                 }
             }
         }
-        aRenderer.flipTexture = false;
     }
 
     public void renderInventoryBlock(Block aBlock, int aMeta, int aModelID, RenderBlocks aRenderer) {
@@ -579,7 +572,7 @@ public class GT_Renderer_Block
         if (aTileEntity == null) {
             return false;
         }
-        if (((aTileEntity instanceof IGregTechTileEntity)) && (((IGregTechTileEntity) aTileEntity).getMetaTileEntity() != null) && (((IGregTechTileEntity) aTileEntity).getMetaTileEntity().renderInWorld(aWorld, aX, aY, aZ, aBlock, aRenderer))) {
+        if (aTileEntity instanceof IGregTechTileEntity && (((IGregTechTileEntity) aTileEntity).getMetaTileEntity() != null) && (((IGregTechTileEntity) aTileEntity).getMetaTileEntity().renderInWorld(aWorld, aX, aY, aZ, aBlock, aRenderer))) {
             return true;
         }
         if ((aTileEntity instanceof IPipeRenderedTileEntity)) {


### PR DESCRIPTION
- Fix all faces use the same UV mapping and orientation to be same as standard
  vanilla full blocks Vanilla blocks's face rendering.
- Fix the orientation of bottom-face's arrow overlay with fixed UV of the
  `GT_MetaTileEntity_Buffer` type machines (filters, buffers, regulators)
- Fix UV mappiong of thick covers
- Remove the now useless and broken custom UVMapped vertices at the bottom face.

![](https://i.imgur.com/MImsbQY.png)