### PR TITLE
1st attempt on fixing small boilers automation. Seems to work correctly 

### DIFF
--- a/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
+++ b/src/main/java/gregtech/common/tileentities/boilers/GT_MetaTileEntity_Boiler.java
@@ -255,14 +255,14 @@ public abstract class GT_MetaTileEntity_Boiler
 
     public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
         if (GT_Mod.gregtechproxy.mAllowSmallBoilerAutomation)
-        return true;
+        return aIndex == 1 || aIndex == 3;
         else
             return false;
     }
 
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
         if(GT_Mod.gregtechproxy.mAllowSmallBoilerAutomation)
-        return true;
+        return aIndex == 2;
         else
             return false;
     }


### PR DESCRIPTION
See https://github.com/Invincible92/GT5-Unofficial/commit/f16a5dab181325e18d9dcda064c7ae8a5430f58b#commitcomment-78010299

The release version on the GT5 GitHub doesn't properly work when the config option "_B:AllowSmallBoilerAutomation_" is set to true. If set as such, it pulls from inventories as hoppers _but_ the combustible materials are put **into** the water buckets/cells section, and then, they get _**immediately**_ pulled from the hopper below the boiler, which it is not the correct way. 

To correct this, I have had to look into the GT++ code through IntelliJ IDEA decompiler (_I'm truly sorry for that @draknyte1_) and compare the boiler _.class_ files betweeen the two sources.

I have taken a screenshot of the change working as it was intended ("_B:AllowSmallBoilerAutomation_" set to true)

![2022-07-08_13 12 10](https://user-images.githubusercontent.com/11424960/177984079-30ff3818-70bc-4da5-9370-48ca930fa411.png)

And this is with "_B:AllowSmallBoilerAutomation_" set to false.

![2022-07-08_13 48 00](https://user-images.githubusercontent.com/11424960/177986749-a0b35e3d-4b57-45be-8191-2c452232a6d0.png)

Hope the change is OK to the PR.